### PR TITLE
Sustain loot wisp magnetization

### DIFF
--- a/petsplus_story.md
+++ b/petsplus_story.md
@@ -86,7 +86,7 @@
 * **Baseline**: +Move Speed scalar; occasional **Glowing** ping on nearby hostiles at combat start.
 * **Current Kit**
 
-  * **L3 – Loot Wisp**: After combat ends, nearby drops and XP within a short radius gently drift toward the owner for a moment.
+  * **L3 – Loot Wisp**: After combat ends, a short-lived wisp (≈4s, configurable) tugs nearby drops and XP within ~12 blocks toward the owner every tick, fading early if the owner leaves the bubble.
 
 ### 3.5 Skyrider (Air Control / Fall Safety)
 


### PR DESCRIPTION
## Summary
- track active magnetization windows and process them each world tick so drops and xp keep drifting while the effect lasts
- respect pickup flags and owner radius when applying pulls and guard against zero-distance velocity updates
- document the sustained loot wisp behavior in the Scout design notes

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d12edfccc0832faca1ae7889e88e1d