### PR TITLE
Sustain loot wisp magnetization

### DIFF
--- a/petsplus_story.md
+++ b/petsplus_story.md
@@ -86,7 +86,7 @@
 * **Baseline**: +Move Speed scalar; occasional **Glowing** ping on nearby hostiles at combat start.
 * **Current Kit**
 
-  * **L3 – Loot Wisp**: After combat ends, nearby drops and XP within a short radius gently drift toward the owner for a moment.
+  * **L3 – Loot Wisp**: After combat ends, a short-lived wisp (≈4s, configurable) tugs nearby drops and XP within ~12 blocks toward the owner every tick, fading early if the owner leaves the bubble.
 
 ### 3.5 Skyrider (Air Control / Fall Safety)
 

--- a/src/main/java/woflo/petsplus/effects/MagnetizeDropsAndXpEffect.java
+++ b/src/main/java/woflo/petsplus/effects/MagnetizeDropsAndXpEffect.java
@@ -1,6 +1,7 @@
 package woflo.petsplus.effects;
 
 import com.google.gson.JsonObject;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.entity.ExperienceOrbEntity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -12,14 +13,25 @@ import woflo.petsplus.api.Effect;
 import woflo.petsplus.api.EffectContext;
 import woflo.petsplus.config.PetsPlusConfig;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.WeakHashMap;
 
 /**
  * Effect that magnetizes item drops and experience orbs toward the owner.
  */
 public class MagnetizeDropsAndXpEffect implements Effect {
     private static final Identifier ID = Identifier.of("petsplus", "magnetize_drops_and_xp");
-    
+
+    private static final Map<ServerWorld, Map<UUID, MagnetizationState>> ACTIVE_MAGNETIZATIONS = new WeakHashMap<>();
+
+    static {
+        ServerTickEvents.END_WORLD_TICK.register(MagnetizeDropsAndXpEffect::tickWorld);
+    }
+
     private final double radius;
     private final int durationTicks;
     
@@ -58,47 +70,131 @@ public class MagnetizeDropsAndXpEffect implements Effect {
     }
     
     private void scheduleMagnetization(ServerWorld world, PlayerEntity owner, double radius, int duration) {
-        // In a real implementation, this would schedule periodic magnetization
-        // For now, we'll do immediate magnetization
-        magnetizeNearbyItems(world, owner, radius);
+        Map<UUID, MagnetizationState> worldStates = ACTIVE_MAGNETIZATIONS.computeIfAbsent(world, w -> new HashMap<>());
+        UUID ownerId = owner.getUuid();
+        long expiryTick = world.getTime() + duration;
+        Vec3d anchor = owner.getPos();
+
+        worldStates.compute(ownerId, (uuid, existing) -> {
+            if (existing == null) {
+                return new MagnetizationState(anchor, radius, expiryTick);
+            }
+            existing.refresh(anchor, radius, expiryTick);
+            return existing;
+        });
+
+        magnetizeNearbyItems(world, owner, anchor, radius);
     }
-    
-    private void magnetizeNearbyItems(ServerWorld world, PlayerEntity owner, double radius) {
-        Vec3d ownerPos = owner.getPos();
-        Box searchBox = Box.of(ownerPos, radius * 2, radius * 2, radius * 2);
-        
+
+    private static void tickWorld(ServerWorld world) {
+        Map<UUID, MagnetizationState> worldStates = ACTIVE_MAGNETIZATIONS.get(world);
+        if (worldStates == null || worldStates.isEmpty()) {
+            return;
+        }
+
+        long currentTick = world.getTime();
+        Iterator<Map.Entry<UUID, MagnetizationState>> iterator = worldStates.entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            Map.Entry<UUID, MagnetizationState> entry = iterator.next();
+            MagnetizationState state = entry.getValue();
+
+            if (currentTick >= state.getExpirationTick()) {
+                iterator.remove();
+                continue;
+            }
+
+            PlayerEntity owner = world.getPlayerByUuid(entry.getKey());
+            if (owner == null || !owner.isAlive()) {
+                iterator.remove();
+                continue;
+            }
+
+            if (owner.getPos().squaredDistanceTo(state.getAnchor()) > state.getRadius() * state.getRadius()) {
+                iterator.remove();
+                continue;
+            }
+
+            magnetizeNearbyItems(world, owner, state.getAnchor(), state.getRadius());
+        }
+
+        if (worldStates.isEmpty()) {
+            ACTIVE_MAGNETIZATIONS.remove(world);
+        }
+    }
+
+    private static void magnetizeNearbyItems(ServerWorld world, PlayerEntity owner, Vec3d center, double radius) {
+        Box searchBox = Box.of(center, radius * 2, radius * 2, radius * 2);
+        double radiusSquared = radius * radius;
+
         // Magnetize item entities
         List<ItemEntity> items = world.getEntitiesByClass(
             ItemEntity.class,
             searchBox,
-            item -> item.squaredDistanceTo(owner) <= radius * radius && !item.cannotPickup()
+            item -> item.squaredDistanceTo(center) <= radiusSquared && !item.cannotPickup()
         );
-        
+
         for (ItemEntity item : items) {
             magnetizeToPlayer(item, owner);
         }
-        
+
         // Magnetize experience orbs
         List<ExperienceOrbEntity> orbs = world.getEntitiesByClass(
             ExperienceOrbEntity.class,
             searchBox,
-            orb -> orb.squaredDistanceTo(owner) <= radius * radius
+            orb -> orb.squaredDistanceTo(center) <= radiusSquared
         );
-        
+
         for (ExperienceOrbEntity orb : orbs) {
             magnetizeToPlayer(orb, owner);
         }
     }
-    
-    private void magnetizeToPlayer(ItemEntity item, PlayerEntity player) {
-        Vec3d direction = player.getPos().subtract(item.getPos()).normalize();
-        Vec3d velocity = direction.multiply(0.1); // Gentle pull
+
+    private static void magnetizeToPlayer(ItemEntity item, PlayerEntity player) {
+        Vec3d toPlayer = player.getPos().subtract(item.getPos());
+        if (toPlayer.lengthSquared() == 0) {
+            return;
+        }
+        Vec3d velocity = toPlayer.normalize().multiply(0.1); // Gentle pull
         item.setVelocity(velocity);
     }
-    
-    private void magnetizeToPlayer(ExperienceOrbEntity orb, PlayerEntity player) {
-        Vec3d direction = player.getPos().subtract(orb.getPos()).normalize();
-        Vec3d velocity = direction.multiply(0.15); // Slightly faster pull for XP
+
+    private static void magnetizeToPlayer(ExperienceOrbEntity orb, PlayerEntity player) {
+        Vec3d toPlayer = player.getPos().subtract(orb.getPos());
+        if (toPlayer.lengthSquared() == 0) {
+            return;
+        }
+        Vec3d velocity = toPlayer.normalize().multiply(0.15); // Slightly faster pull for XP
         orb.setVelocity(velocity);
+    }
+
+    private static class MagnetizationState {
+        private Vec3d anchor;
+        private double radius;
+        private long expirationTick;
+
+        private MagnetizationState(Vec3d anchor, double radius, long expirationTick) {
+            this.anchor = anchor;
+            this.radius = radius;
+            this.expirationTick = expirationTick;
+        }
+
+        private Vec3d getAnchor() {
+            return anchor;
+        }
+
+        private double getRadius() {
+            return radius;
+        }
+
+        private long getExpirationTick() {
+            return expirationTick;
+        }
+
+        private void refresh(Vec3d newAnchor, double newRadius, long newExpiryTick) {
+            this.anchor = newAnchor;
+            this.radius = Math.max(this.radius, newRadius);
+            this.expirationTick = Math.max(this.expirationTick, newExpiryTick);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- track active magnetization windows and process them each world tick so drops and xp keep drifting while the effect lasts
- respect pickup flags, honor the wisp’s anchor when scanning for entities, and guard against zero-distance velocity updates
- document the sustained loot wisp behavior in the Scout design notes

## Testing
- `bash ./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d12edfccc0832faca1ae7889e88e1d