### PR TITLE
Polish Striker execution momentum and cues

### DIFF
--- a/petsplus_story.md
+++ b/petsplus_story.md
@@ -62,7 +62,7 @@
 * **Baseline**: +Attack Damage/Speed scalars (tunable caps).
 * **Current Kit**
 
-  * **Execution (owner-based, pet-agnostic)**: When a Striker pet is nearby, the owner gains a modest bonus vs low‑health targets that have been recently damaged in the skirmish.
+  * **Execution (owner-based, pet-agnostic)**: With a Striker nearby, once a foe you've recently tagged dips under the execute threshold (default 35% HP), your follow-up strike becomes a true finisher and slays them outright (boss-safe). Chaining executions within ~3s now ramps an "execution momentum" buff — every finisher adds roughly +2% (slightly stronger as your Striker levels) to the threshold, refreshing the window, yet hard-capped at 45%. Let it lapse and the buff bleeds off a stack at a time instead of dropping to zero, giving you a short grace period. Successful streaks spark a faint soul-flame flourish and a soft sweep hit that climbs in pitch with your momentum for immersive but unobtrusive feedback.
   * **L7 – Finisher Mark**: Hitting a target under a threshold can tag it, empowering the owner's next attack greatly vs that target and applying a short slow on hit. Brief mount pep when mounted.
 
 ### 3.3 Support (Potion Aura / Safeguard)

--- a/src/main/java/woflo/petsplus/config/PetsPlusConfig.java
+++ b/src/main/java/woflo/petsplus/config/PetsPlusConfig.java
@@ -87,7 +87,10 @@ public class PetsPlusConfig {
         
         // Striker config
         JsonObject striker = new JsonObject();
-        striker.addProperty("ownerExecuteBonusPct", 0.10);
+        striker.addProperty("executeThresholdPct", 0.35);
+        striker.addProperty("executeChainBonusPerStackPct", 0.02);
+        striker.addProperty("executeChainMaxStacks", 5);
+        striker.addProperty("executeChainDurationTicks", 60);
         striker.addProperty("finisherMarkBonusPct", 0.20);
         striker.addProperty("finisherMarkDurationTicks", 80);
         config.add("striker", striker);

--- a/src/main/java/woflo/petsplus/mixin/PlayerAttackMixin.java
+++ b/src/main/java/woflo/petsplus/mixin/PlayerAttackMixin.java
@@ -29,14 +29,15 @@ public class PlayerAttackMixin {
         PlayerEntity player = (PlayerEntity) (Object) this;
         
         if (target instanceof LivingEntity livingTarget) {
-            float executionBonus = StrikerExecution.calculateExecutionBonus(player, livingTarget, damage);
-            if (executionBonus > 0 && player.getWorld() instanceof net.minecraft.server.world.ServerWorld serverWorld) {
+            StrikerExecution.ExecutionResult execution = StrikerExecution.evaluateExecution(player, livingTarget, damage);
+            if (execution.triggered() && player.getWorld() instanceof net.minecraft.server.world.ServerWorld serverWorld) {
                 // Emit feedback for successful execution
-                woflo.petsplus.ui.FeedbackManager.emitStrikerExecution(player, serverWorld);
+                woflo.petsplus.ui.FeedbackManager.emitStrikerExecution(player, livingTarget, serverWorld,
+                        execution.momentumStacks(), execution.momentumFill());
             }
-            return damage + executionBonus;
+            return execution.totalDamage(damage);
         }
-        
+
         return damage;
     }
     

--- a/src/main/java/woflo/petsplus/roles/striker/StrikerCore.java
+++ b/src/main/java/woflo/petsplus/roles/striker/StrikerCore.java
@@ -95,6 +95,6 @@ public class StrikerCore {
             return 0.0f;
         }
         
-        return StrikerExecution.calculateExecutionBonus(player, target, 1.0f);
+        return StrikerExecution.evaluateExecution(player, target, 1.0f, false).bonusDamage();
     }
 }

--- a/src/main/java/woflo/petsplus/roles/striker/StrikerExecution.java
+++ b/src/main/java/woflo/petsplus/roles/striker/StrikerExecution.java
@@ -4,6 +4,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.MathHelper;
 import woflo.petsplus.Petsplus;
 import woflo.petsplus.config.PetsPlusConfig;
 import woflo.petsplus.effects.TagTargetEffect;
@@ -12,9 +13,11 @@ import woflo.petsplus.state.PetComponent;
 import woflo.petsplus.util.BossSafetyUtil;
 
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.UUID;
+import java.util.WeakHashMap;
 
 /**
  * Striker execution system - provides damage bonuses against low-health enemies.
@@ -23,6 +26,41 @@ public class StrikerExecution {
     // Track recent damage stamps per target to validate execution window and ownership
     private static final Map<LivingEntity, DamageStamp> RECENT_DAMAGE = new WeakHashMap<>();
     private record DamageStamp(UUID ownerId, long tick) {}
+
+    // Track short-lived execution momentum stacks per owner for the temporary threshold bonus
+    private static final Map<UUID, ExecutionMomentum> EXECUTION_MOMENTUM = new HashMap<>();
+    private record ExecutionMomentum(int stacks, long expiresAtTick, int durationTicks) {
+        float normalizedFill(long now) {
+            if (expiresAtTick <= now) {
+                return 0.0f;
+            }
+            if (durationTicks <= 0) {
+                return 1.0f;
+            }
+            return MathHelper.clamp((expiresAtTick - now) / (float) durationTicks, 0.0f, 1.0f);
+        }
+    }
+
+    private record MomentumState(int stacks, float fill) {
+        static final MomentumState EMPTY = new MomentumState(0, 0.0f);
+    }
+
+    private static final double DEFAULT_CHAIN_STACK_BONUS = 0.02; // +2% threshold per stack
+    private static final int DEFAULT_CHAIN_MAX_STACKS = 5; // Caps at +10%
+    private static final int DEFAULT_CHAIN_DURATION_TICKS = 60; // 3 seconds @20 tps
+    private static final double MAX_EXECUTE_THRESHOLD = 0.45; // Hard cap for momentum window
+
+    /** Result returned when evaluating a potential execution. */
+    public record ExecutionResult(float bonusDamage,
+                                  boolean triggered,
+                                  float appliedThresholdPct,
+                                  int strikerLevel,
+                                  int momentumStacks,
+                                  float momentumFill) {
+        public float totalDamage(float baseDamage) {
+            return baseDamage + bonusDamage;
+        }
+    }
     
     /**
      * Calculate execution bonus damage for owner attacks.
@@ -32,39 +70,101 @@ public class StrikerExecution {
      * @return The additional execution damage to apply
      */
     public static float calculateExecutionBonus(PlayerEntity attacker, LivingEntity target, float baseDamage) {
-        if (attacker == null || target == null || baseDamage <= 0) return 0.0f;
-        if (!target.isAlive()) return 0.0f;
+        return evaluateExecution(attacker, target, baseDamage, true).bonusDamage();
+    }
 
-        // Find nearby Striker pet
+    public static float calculateExecutionBonus(PlayerEntity attacker, LivingEntity target, float baseDamage, boolean applyMomentum) {
+        return evaluateExecution(attacker, target, baseDamage, applyMomentum).bonusDamage();
+    }
+
+    public static ExecutionResult evaluateExecution(PlayerEntity attacker, LivingEntity target, float baseDamage) {
+        return evaluateExecution(attacker, target, baseDamage, true);
+    }
+
+    public static ExecutionResult evaluateExecution(PlayerEntity attacker, LivingEntity target, float baseDamage, boolean applyMomentum) {
+        if (attacker == null || target == null || baseDamage <= 0) {
+            return new ExecutionResult(0.0f, false, 0.0f, 0, 0, 0.0f);
+        }
+        if (!target.isAlive()) {
+            return new ExecutionResult(0.0f, false, 0.0f, 0, 0, 0.0f);
+        }
+
+        // Find the strongest nearby Striker pet contributing to the execution
         MobEntity strikerPet = findNearbyStrikerPet(attacker);
         if (strikerPet == null) {
-            return 0.0f;
+            return new ExecutionResult(0.0f, false, 0.0f, 0, 0, 0.0f);
         }
-        
-        // Safety: avoid allies/teammates and bosses
-        if (attacker.isTeammate(target)) return 0.0f;
-        if (BossSafetyUtil.isBossEntity(target)) return 0.0f;
 
-        // Configurable execution threshold
-        double threshold = clamp01(PetsPlusConfig.getInstance().getDouble("striker", "executeThresholdPct", 0.35));
-        float targetHealthPercent = Math.max(0f, target.getHealth()) / Math.max(1f, target.getMaxHealth());
-        if (targetHealthPercent > (float) threshold) {
-            return 0.0f; // Target not low enough for execution
+        PetComponent strikerComponent = PetComponent.get(strikerPet);
+        int strikerLevel = strikerComponent != null ? Math.max(1, strikerComponent.getLevel()) : 1;
+        float levelProgress = strikerComponent != null
+                ? MathHelper.clamp((strikerLevel - 1) / 29.0f, 0.0f, 1.0f)
+                : 0.0f;
+
+        // Safety: avoid allies/teammates and bosses
+        if (attacker.isTeammate(target)) {
+            return new ExecutionResult(0.0f, false, 0.0f, strikerLevel, 0, 0.0f);
         }
-        
+        if (BossSafetyUtil.isBossEntity(target)) {
+            return new ExecutionResult(0.0f, false, 0.0f, strikerLevel, 0, 0.0f);
+        }
+
+        PetsPlusConfig config = PetsPlusConfig.getInstance();
+        double baseThreshold = clamp01(config.getDouble("striker", "executeThresholdPct", 0.35));
+        baseThreshold = Math.min(baseThreshold, MAX_EXECUTE_THRESHOLD);
+
+        double chainBonusPerStack = clamp01(config.getDouble("striker", "executeChainBonusPerStackPct", DEFAULT_CHAIN_STACK_BONUS));
+        double leveledBonusPerStack = Math.min(MAX_EXECUTE_THRESHOLD,
+                chainBonusPerStack * (1.0 + 0.25 * levelProgress));
+        int chainMaxStacks = Math.max(0, config.getInt("striker", "executeChainMaxStacks", DEFAULT_CHAIN_MAX_STACKS));
+        int baseChainDurationTicks = Math.max(1, config.getInt("striker", "executeChainDurationTicks", DEFAULT_CHAIN_DURATION_TICKS));
+        int leveledChainDurationTicks = Math.max(baseChainDurationTicks,
+                (int) Math.round(baseChainDurationTicks * (1.0 + 0.25 * levelProgress)));
+
+        MomentumState momentumState = chainMaxStacks > 0 ? getMomentumState(attacker) : MomentumState.EMPTY;
+        int activeStacks = chainMaxStacks > 0 ? Math.min(chainMaxStacks, momentumState.stacks()) : 0;
+        float momentumFill = chainMaxStacks > 0 ? momentumState.fill() : 0.0f;
+
+        double appliedThreshold = computeAppliedThreshold(baseThreshold, leveledBonusPerStack, chainMaxStacks, activeStacks);
+
+        float targetHealthPercent = Math.max(0f, target.getHealth()) / Math.max(1f, target.getMaxHealth());
+        if (targetHealthPercent > (float) appliedThreshold) {
+            return new ExecutionResult(0.0f, false, (float) appliedThreshold, strikerLevel, activeStacks, momentumFill);
+        }
+
         // Check if target has been recently damaged by this owner (or their pet)
         if (!hasRecentDamageFromOwnerOrPet(target, attacker)) {
-            return 0.0f;
+            return new ExecutionResult(0.0f, false, (float) appliedThreshold, strikerLevel, activeStacks, momentumFill);
         }
-        
-        // Calculate execution bonus
-        double bonusPercent = PetsPlusConfig.getInstance().getDouble("striker", "ownerExecuteBonusPct", 0.10);
-        float bonusDamage = (float) (baseDamage * bonusPercent);
-        
-        Petsplus.LOGGER.debug("Striker execution bonus: {}% extra damage ({}) against {}", 
-                             bonusPercent * 100, bonusDamage, target.getName().getString());
-        
-        return bonusDamage;
+
+        float effectiveHealth = Math.max(0f, target.getHealth()) + Math.max(0f, target.getAbsorptionAmount());
+        if (effectiveHealth <= 0f) {
+            return new ExecutionResult(0.0f, false, (float) appliedThreshold, strikerLevel, activeStacks, momentumFill);
+        }
+
+        // Return enough bonus damage to finish the target outright without heavy overkill.
+        float bonusDamage = Math.max(0f, effectiveHealth - Math.max(0f, baseDamage));
+
+        MomentumState resultingState = momentumState;
+        if (applyMomentum && chainMaxStacks > 0) {
+            resultingState = incrementMomentumStacks(attacker, chainMaxStacks, leveledChainDurationTicks);
+        }
+        int resultingStacks = chainMaxStacks > 0 ? resultingState.stacks() : 0;
+        float resultingFill = chainMaxStacks > 0 ? resultingState.fill() : momentumFill;
+
+        if (applyMomentum) {
+            double nextThreshold = computeAppliedThreshold(baseThreshold, leveledBonusPerStack, chainMaxStacks, resultingStacks);
+            Petsplus.LOGGER.debug("Striker execution triggered: L{} executed {} at {}% HP (threshold {}% -> next {}% | chain stacks: {} -> +{}%)",
+                    strikerLevel,
+                    target.getName().getString(),
+                    String.format(Locale.ROOT, "%.1f", targetHealthPercent * 100f),
+                    String.format(Locale.ROOT, "%.1f", appliedThreshold * 100.0),
+                    String.format(Locale.ROOT, "%.1f", nextThreshold * 100.0),
+                    resultingStacks,
+                    String.format(Locale.ROOT, "%.1f", Math.max(0, nextThreshold - baseThreshold) * 100.0));
+        }
+
+        return new ExecutionResult(bonusDamage, true, (float) appliedThreshold, strikerLevel, resultingStacks, resultingFill);
     }
     
     /**
@@ -120,7 +220,14 @@ public class StrikerExecution {
                            entity.isAlive() &&
                            component.isOwnedBy(owner);
                 }
-        ).stream().min(Comparator.comparingDouble(e -> e.squaredDistanceTo(owner))).orElse(null);
+        ).stream().max(
+                Comparator
+                        .comparingInt((MobEntity entity) -> {
+                            PetComponent component = PetComponent.get(entity);
+                            return component != null ? component.getLevel() : 0;
+                        })
+                        .thenComparingDouble(entity -> -entity.squaredDistanceTo(owner))
+        ).orElse(null);
     }
     
     private static boolean hasRecentDamageFromOwnerOrPet(LivingEntity target, PlayerEntity owner) {
@@ -151,5 +258,80 @@ public class StrikerExecution {
         RECENT_DAMAGE.put(target, new DamageStamp(owner.getUuid(), owner.getWorld().getTime()));
     }
 
+    private static MomentumState getMomentumState(PlayerEntity owner) {
+        if (owner == null) {
+            return MomentumState.EMPTY;
+        }
+
+        ExecutionMomentum momentum = EXECUTION_MOMENTUM.get(owner.getUuid());
+        if (momentum == null) {
+            return MomentumState.EMPTY;
+        }
+
+        if (!(owner.getWorld() instanceof ServerWorld serverWorld)) {
+            return new MomentumState(momentum.stacks(), 1.0f);
+        }
+
+        long now = serverWorld.getTime();
+        if (momentum.expiresAtTick() <= now) {
+            if (momentum.stacks() > 1) {
+                int downgradedStacks = momentum.stacks() - 1;
+                long expiresAt = now + Math.max(1, momentum.durationTicks());
+                ExecutionMomentum downgraded = new ExecutionMomentum(downgradedStacks, expiresAt, momentum.durationTicks());
+                EXECUTION_MOMENTUM.put(owner.getUuid(), downgraded);
+                return new MomentumState(downgraded.stacks(), downgraded.normalizedFill(now));
+            }
+            EXECUTION_MOMENTUM.remove(owner.getUuid());
+            return MomentumState.EMPTY;
+        }
+
+        return new MomentumState(momentum.stacks(), momentum.normalizedFill(now));
+    }
+
+    private static int getActiveMomentumStacks(PlayerEntity owner) {
+        return getMomentumState(owner).stacks();
+    }
+
+    private static MomentumState incrementMomentumStacks(PlayerEntity owner, int maxStacks, int durationTicks) {
+        if (owner == null || maxStacks <= 0 || durationTicks <= 0) {
+            return MomentumState.EMPTY;
+        }
+
+        if (!(owner.getWorld() instanceof ServerWorld serverWorld)) {
+            return MomentumState.EMPTY;
+        }
+
+        long now = serverWorld.getTime();
+        ExecutionMomentum momentum = EXECUTION_MOMENTUM.get(owner.getUuid());
+        int stacks;
+        if (momentum != null && momentum.expiresAtTick() > now) {
+            stacks = Math.min(maxStacks, momentum.stacks() + 1);
+        } else {
+            stacks = 1;
+        }
+
+        long expiresAt = now + Math.max(1, durationTicks);
+        ExecutionMomentum updated = new ExecutionMomentum(stacks, expiresAt, durationTicks);
+        EXECUTION_MOMENTUM.put(owner.getUuid(), updated);
+        return new MomentumState(updated.stacks(), updated.normalizedFill(now));
+    }
+
     private static double clamp01(double v) { return v < 0 ? 0 : (v > 1 ? 1 : v); }
+
+    private static double computeAppliedThreshold(double baseThreshold, double perStackBonus, int chainMaxStacks, int stacks) {
+        double sanitizedBase = clamp01(Math.min(baseThreshold, MAX_EXECUTE_THRESHOLD));
+        if (perStackBonus <= 0 || chainMaxStacks <= 0 || stacks <= 0) {
+            return sanitizedBase;
+        }
+
+        double capacity = Math.max(0.0, MAX_EXECUTE_THRESHOLD - sanitizedBase);
+        if (capacity <= 0.0) {
+            return sanitizedBase;
+        }
+
+        double effectivePerStack = Math.min(perStackBonus, capacity);
+        double appliedStacks = Math.min(stacks, chainMaxStacks);
+        double bonus = Math.min(capacity, appliedStacks * effectivePerStack);
+        return clamp01(sanitizedBase + bonus);
+    }
 }

--- a/src/main/java/woflo/petsplus/roles/striker/StrikerExecutionFallback.java
+++ b/src/main/java/woflo/petsplus/roles/striker/StrikerExecutionFallback.java
@@ -1,13 +1,7 @@
 package woflo.petsplus.roles.striker;
 
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.world.ServerWorld;
-import woflo.petsplus.api.PetRole;
-import woflo.petsplus.config.PetsPlusConfig;
-import woflo.petsplus.state.PetComponent;
-import woflo.petsplus.util.BossSafetyUtil;
 
 /**
  * Striker execution fallback behaviors.
@@ -18,45 +12,8 @@ public class StrikerExecutionFallback {
      * Apply owner execution bonus vs targets under 35% HP if target has recent damage.
      */
     public static float applyOwnerExecuteBonus(PlayerEntity owner, LivingEntity target, float baseDamage) {
-        if (!(owner.getWorld() instanceof ServerWorld serverWorld)) {
-            return baseDamage;
-        }
-        
-        // Safety: avoid allies/teammates and bosses
-        if (owner.isTeammate(target)) return baseDamage;
-        if (BossSafetyUtil.isBossEntity(target)) return baseDamage;
-
-        // Check if target is under configured HP threshold
-        double threshold = Math.max(0, Math.min(1, PetsPlusConfig.getInstance().getDouble("striker", "executeThresholdPct", 0.35)));
-        float targetHealthPct = Math.max(0f, target.getHealth()) / Math.max(1f, target.getMaxHealth());
-        if (targetHealthPct > (float) threshold) {
-            return baseDamage;
-        }
-        
-        // Check if we have Striker pets
-        boolean hasStrikerPet = !serverWorld.getEntitiesByClass(
-            MobEntity.class,
-            owner.getBoundingBox().expand(16),
-            entity -> {
-                PetComponent component = PetComponent.get(entity);
-                return component != null && 
-                       component.getRole().equals(PetRole.STRIKER) &&
-                       component.isOwnedBy(owner) &&
-                       entity.isAlive();
-            }
-        ).isEmpty();
-        
-        if (!hasStrikerPet) {
-            return baseDamage;
-        }
-        
-        // Check if target has recent damage from owner or pet
-        if (woflo.petsplus.roles.striker.StrikerExecution.hasRecentDamageWindow(target, owner)) {
-            double bonusPct = PetsPlusConfig.getInstance().getDouble("striker", "ownerExecuteBonusPct", 0.10);
-            return baseDamage * (1.0f + (float) bonusPct);
-        }
-        
-        return baseDamage;
+        StrikerExecution.ExecutionResult result = StrikerExecution.evaluateExecution(owner, target, baseDamage);
+        return result.totalDamage(baseDamage);
     }
     
     /**


### PR DESCRIPTION
## Summary
- tighten Striker execution evaluation with level-tuned momentum stacks, a 45% cap, and gradual stack decay for a smoother rhythm
- drive dynamic execution particles and sweep audio that scale with active momentum stacks
- document the refreshed execution momentum behavior and feedback in the Striker story entry

## Testing
- bash ./gradlew check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d12e427918832fadc03fa3a56ee84d