### PR TITLE
Align support potion pulses with intended cadence

### DIFF
--- a/src/main/java/woflo/petsplus/roles/support/SupportPotionUtils.java
+++ b/src/main/java/woflo/petsplus/roles/support/SupportPotionUtils.java
@@ -24,6 +24,10 @@ public final class SupportPotionUtils {
      * Each pulse consumes one charge before perch discounts are applied.
      */
     public static final double BASE_PULSES_PER_POTION = 8.0;
+    /**
+     * Interval between stored potion aura pulses (7 seconds at 20 ticks per second).
+     */
+    public static final int SUPPORT_POTION_PULSE_INTERVAL_TICKS = 140;
 
     private static final int DEFAULT_BASE_POTION_DURATION_TICKS = 3600;
     private static final double MIN_INITIAL_CHARGES = 1.0;

--- a/src/main/java/woflo/petsplus/state/StateManager.java
+++ b/src/main/java/woflo/petsplus/state/StateManager.java
@@ -263,6 +263,11 @@ public class StateManager {
             return;
         }
 
+        long currentTime = world.getTime();
+        if (currentTime % woflo.petsplus.roles.support.SupportPotionUtils.SUPPORT_POTION_PULSE_INTERVAL_TICKS != 0) {
+            return;
+        }
+
         var potionState = woflo.petsplus.roles.support.SupportPotionUtils.getStoredState(comp);
         if (!potionState.isValid()) {
             return;
@@ -301,10 +306,8 @@ public class StateManager {
             }
         }
 
-        // Emit feedback for potion pulse (less frequent)
-        if (world.getTime() % 100 == 0) { // Every 5 seconds
-            woflo.petsplus.ui.FeedbackManager.emitFeedback("support_potion_pulse", pet, serverWorld);
-        }
+        // Emit feedback for potion pulse (aligned with actual cadence)
+        woflo.petsplus.ui.FeedbackManager.emitFeedback("support_potion_pulse", pet, serverWorld);
 
         double consumption = woflo.petsplus.roles.support.SupportPotionUtils.getConsumptionPerPulse(comp);
         woflo.petsplus.roles.support.SupportPotionUtils.consumeCharges(comp, potionState, consumption);


### PR DESCRIPTION
## Summary
- add a shared constant for the support potion pulse interval to capture the 7-second cadence
- gate stored potion aura application and charge consumption to that cadence so bottles last the expected duration
- trigger the pulse feedback on the same cadence for consistent visuals

## Testing
- bash gradlew check --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d14c7d6fc0832f88bf938e1e30f4eb