### PR TITLE
Fix datapack loader resource roots

### DIFF
--- a/src/main/java/woflo/petsplus/data/AbilityDataLoader.java
+++ b/src/main/java/woflo/petsplus/data/AbilityDataLoader.java
@@ -48,13 +48,18 @@ public class AbilityDataLoader implements SimpleSynchronousResourceReloadListene
         Map<Identifier, Resource> resources = manager.findResources(ROOT_PATH, id -> id.getPath().endsWith(".json"));
         for (Identifier resourceId : resources.keySet()) {
             List<Resource> stack = manager.getAllResources(resourceId);
+            JsonElement resolved = null;
             for (Resource resource : stack) {
                 try (Reader reader = resource.getReader()) {
-                    JsonElement json = JsonParser.parseReader(reader);
-                    prepared.put(toAbilityId(resourceId), json);
+                    resolved = JsonParser.parseReader(reader);
+                    break;
                 } catch (IOException | JsonParseException e) {
                     Petsplus.LOGGER.error("Failed to parse ability data from {}", resourceId, e);
                 }
+            }
+
+            if (resolved != null) {
+                prepared.put(toAbilityId(resourceId), resolved);
             }
         }
 

--- a/src/main/java/woflo/petsplus/data/PetRoleDataLoader.java
+++ b/src/main/java/woflo/petsplus/data/PetRoleDataLoader.java
@@ -40,14 +40,19 @@ public final class PetRoleDataLoader implements SimpleSynchronousResourceReloadL
         Map<Identifier, Resource> located = manager.findResources(ROOT_PATH, id -> id.getPath().endsWith(".json"));
         for (Identifier resourceId : located.keySet()) {
             List<Resource> stack = manager.getAllResources(resourceId);
+            JsonElement resolved = null;
 
             for (Resource resource : stack) {
                 try (Reader reader = resource.getReader()) {
-                    JsonElement json = JsonParser.parseReader(reader);
-                    prepared.put(toRoleId(resourceId), json);
+                    resolved = JsonParser.parseReader(reader);
+                    break;
                 } catch (IOException | JsonParseException e) {
                     Petsplus.LOGGER.error("Failed to parse role data from {}", resourceId, e);
                 }
+            }
+
+            if (resolved != null) {
+                prepared.put(toRoleId(resourceId), resolved);
             }
         }
 


### PR DESCRIPTION
## Summary
- point the ability datapack loader at the namespace-relative abilities folder and strip the folder prefix when deriving ability ids
- align the pet role loader with the roles folder layout so datapack overrides resolve using identifier-based lookups
- ensure the ability and role datapack loaders respect pack priority so higher-priority overrides win

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d29ecbfbe4832faed514f88141947d