### PR TITLE
Restore tag_target custom targets

### DIFF
--- a/src/main/java/woflo/petsplus/api/registry/PetsPlusRegistries.java
+++ b/src/main/java/woflo/petsplus/api/registry/PetsPlusRegistries.java
@@ -323,7 +323,8 @@ public final class PetsPlusRegistries {
             .build());
 
         registerEffectSerializer(EffectSerializer.builder(id("tag_target"), TagTargetConfig.CODEC,
-            (abilityId, config, context) -> DataResult.success(new TagTargetEffect(config.key(), config.durationTicks())))
+            (abilityId, config, context) -> DataResult.success(new TagTargetEffect(
+                config.targetKey(), config.key(), config.durationTicks())))
             .description("Applies a named tag to the current target.")
             .build());
 
@@ -484,8 +485,9 @@ public final class PetsPlusRegistries {
 
     }
 
-    private record TagTargetConfig(String key, int durationTicks) {
+    private record TagTargetConfig(String targetKey, String key, int durationTicks) {
         static final Codec<TagTargetConfig> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Codec.STRING.optionalFieldOf("target", "target").forGetter(TagTargetConfig::targetKey),
             Codec.STRING.optionalFieldOf("key", "").forGetter(TagTargetConfig::key),
             Codec.INT.optionalFieldOf("duration_ticks", 80).forGetter(TagTargetConfig::durationTicks)
         ).apply(instance, TagTargetConfig::new));

--- a/src/main/java/woflo/petsplus/datagen/SimpleDataGenerator.java
+++ b/src/main/java/woflo/petsplus/datagen/SimpleDataGenerator.java
@@ -314,81 +314,60 @@ public class SimpleDataGenerator {
     private static JsonObject createPhasePartner() {
         JsonObject ability = new JsonObject();
         ability.addProperty("id", "petsplus:phase_partner");
-        
+        ability.addProperty("description", "Teleport tether to owner");
+        ability.addProperty("required_level", 23);
+
         JsonObject trigger = new JsonObject();
-        trigger.addProperty("event", "after_pet_blink");
-        trigger.addProperty("internal_cd_ticks", "${eclipsed.phaseChargeInternalCdTicks}");
+        trigger.addProperty("event", "on_combat_end");
+        trigger.addProperty("cooldown_ticks", 200);
         ability.add("trigger", trigger);
-        
+
         JsonArray effects = new JsonArray();
-        
-        // Speed buff if perched
-        JsonObject speedBuff = new JsonObject();
-        speedBuff.addProperty("type", "buff");
-        speedBuff.addProperty("target", "owner");
-        speedBuff.addProperty("id", "minecraft:speed");
-        speedBuff.addProperty("duration", 40);
-        speedBuff.addProperty("amplifier", 0);
-        speedBuff.addProperty("only_if_perched", true);
-        effects.add(speedBuff);
-        
-        // Attack bonus
-        JsonObject attackBonus = new JsonObject();
-        attackBonus.addProperty("type", "owner_next_attack_bonus");
-        attackBonus.addProperty("bonus_damage_pct", "${eclipsed.phaseChargeBonusDamagePct}");
-        attackBonus.addProperty("expire_ticks", "${eclipsed.phaseChargeWindowTicks}");
-        
-        JsonObject slownessEffect = new JsonObject();
-        slownessEffect.addProperty("type", "effect");
-        slownessEffect.addProperty("target", "victim");
-        slownessEffect.addProperty("id", "minecraft:slowness");
-        slownessEffect.addProperty("duration", 40);
-        slownessEffect.addProperty("amplifier", 0);
-        attackBonus.add("on_hit_effect", slownessEffect);
-        effects.add(attackBonus);
-        
+
+        JsonObject retarget = new JsonObject();
+        retarget.addProperty("type", "retarget_nearest_hostile");
+        retarget.addProperty("radius", 12);
+        retarget.addProperty("store_as", "pp_target");
+        effects.add(retarget);
+
+        JsonObject tagEffect = new JsonObject();
+        tagEffect.addProperty("type", "tag_target");
+        tagEffect.addProperty("target", "pp_target");
+        tagEffect.addProperty("key", "petsplus:phase_partner");
+        tagEffect.addProperty("duration_ticks", 80);
+        effects.add(tagEffect);
+
         ability.add("effects", effects);
         return ability;
     }
-    
+
     private static JsonObject createPerchPing() {
         JsonObject ability = new JsonObject();
         ability.addProperty("id", "petsplus:perch_ping");
-        
+        ability.addProperty("description", "Perch reconnaissance ping");
+        ability.addProperty("required_level", 27);
+
         JsonObject trigger = new JsonObject();
         trigger.addProperty("event", "interval_while_active");
-        trigger.addProperty("ticks", "${eclipsed.perchPingIntervalTicks}");
+        trigger.addProperty("ticks", 40);
         trigger.addProperty("require_perched", true);
-        trigger.addProperty("require_in_combat", true);
         ability.add("trigger", trigger);
-        
+
         JsonArray effects = new JsonArray();
-        
-        // Retarget nearest hostile
+
         JsonObject retarget = new JsonObject();
         retarget.addProperty("type", "retarget_nearest_hostile");
-        retarget.addProperty("radius", "${eclipsed.perchPingRadius}");
+        retarget.addProperty("radius", 12);
         retarget.addProperty("store_as", "pp_target");
         effects.add(retarget);
-        
-        // Apply darkness to target
-        JsonObject darknessEffect = new JsonObject();
-        darknessEffect.addProperty("type", "effect");
-        darknessEffect.addProperty("target", "pp_target");
-        darknessEffect.addProperty("id", "minecraft:darkness");
-        darknessEffect.addProperty("duration", 10);
-        darknessEffect.addProperty("amplifier", 0);
-        darknessEffect.addProperty("boss_safe", true);
-        effects.add(darknessEffect);
-        
-        // Tag target
+
         JsonObject tagEffect = new JsonObject();
         tagEffect.addProperty("type", "tag_target");
         tagEffect.addProperty("target", "pp_target");
         tagEffect.addProperty("key", "petsplus:voidbrand");
         tagEffect.addProperty("duration_ticks", 60);
         effects.add(tagEffect);
-        
+
         ability.add("effects", effects);
         return ability;
     }

--- a/src/main/java/woflo/petsplus/effects/TagTargetEffect.java
+++ b/src/main/java/woflo/petsplus/effects/TagTargetEffect.java
@@ -15,10 +15,12 @@ public class TagTargetEffect implements Effect {
     private static final Identifier ID = Identifier.of("petsplus", "tag_target");
     private static final Map<Entity, Map<String, Long>> ENTITY_TAGS = new HashMap<>();
     
+    private final String targetKey;
     private final String key;
     private final int durationTicks;
-    
-    public TagTargetEffect(String key, int durationTicks) {
+
+    public TagTargetEffect(String targetKey, String key, int durationTicks) {
+        this.targetKey = targetKey == null || targetKey.isBlank() ? "target" : targetKey;
         this.key = key;
         this.durationTicks = durationTicks;
     }
@@ -45,10 +47,21 @@ public class TagTargetEffect implements Effect {
     }
     
     private Entity getTarget(EffectContext context) {
-        // Try to get explicit target first
-        Entity target = context.getTarget();
-        if (target != null) return target;
-        
+        Entity target = context.getData(targetKey, Entity.class);
+        if (target != null) {
+            return target;
+        }
+
+        target = context.getTriggerContext().getData(targetKey, Entity.class);
+        if (target != null) {
+            return target;
+        }
+
+        target = context.getTarget();
+        if (target != null) {
+            return target;
+        }
+
         // Fall back to victim from trigger context
         return context.getTriggerContext().getVictim();
     }

--- a/src/main/resources/data/petsplus/abilities/perch_ping.json
+++ b/src/main/resources/data/petsplus/abilities/perch_ping.json
@@ -9,6 +9,11 @@
   },
   "effects": [
     {
+      "type": "retarget_nearest_hostile",
+      "radius": 12,
+      "store_as": "pp_target"
+    },
+    {
       "type": "tag_target",
       "target": "pp_target",
       "key": "petsplus:voidbrand",

--- a/src/main/resources/data/petsplus/abilities/phase_partner.json
+++ b/src/main/resources/data/petsplus/abilities/phase_partner.json
@@ -8,6 +8,11 @@
   },
   "effects": [
     {
+      "type": "retarget_nearest_hostile",
+      "radius": 12,
+      "store_as": "pp_target"
+    },
+    {
       "type": "tag_target",
       "target": "pp_target",
       "key": "petsplus:phase_partner",


### PR DESCRIPTION
## Summary
- allow the tag_target effect configuration to accept an explicit stored target key and honor it when executing
- ensure the perch_ping and phase_partner ability data retargets an entity before applying the tag and mirror the same structure in the simple data generator

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68d2a90c4ffc832f9dcd743b03f085f7