### PR TITLE
Refactor feedback scheduling to main thread

### DIFF
--- a/src/main/java/woflo/petsplus/ui/FeedbackManager.java
+++ b/src/main/java/woflo/petsplus/ui/FeedbackManager.java
@@ -1,5 +1,6 @@
 package woflo.petsplus.ui;
 
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.mob.MobEntity;
@@ -9,15 +10,18 @@ import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
-import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
 import woflo.petsplus.api.registry.PetRoleType;
 import woflo.petsplus.api.registry.PetsPlusRegistries;
 import woflo.petsplus.state.PetComponent;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Centralized feedback system for visual and audio effects throughout the mod.
@@ -26,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 public class FeedbackManager {
 
     private static final int AMBIENT_PARTICLE_INTERVAL = 80; // 4 seconds
+    private static final Map<ServerWorld, List<DelayedFeedbackTask>> DELAYED_TASKS = new HashMap<>();
+    private static boolean tickHandlerRegistered;
 
     /**
      * Emit feedback for a specific event at an entity's location.
@@ -43,17 +49,108 @@ public class FeedbackManager {
         if (effect == null) return;
 
         if (effect.delayTicks > 0) {
-            // Schedule delayed feedback
-            CompletableFuture.runAsync(() -> {
-                try {
-                    Thread.sleep(effect.delayTicks * 50L); // Convert ticks to milliseconds
-                    executeImmediateFeedback(effect, position, world, sourceEntity);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            });
+            scheduleDelayedFeedback(effect, position, world, sourceEntity);
         } else {
-            executeImmediateFeedback(effect, position, world, sourceEntity);
+            runImmediateFeedback(effect, position, world, sourceEntity);
+        }
+    }
+
+    private static void runImmediateFeedback(FeedbackConfig.FeedbackEffect effect, Vec3d position,
+                                             ServerWorld world, Entity sourceEntity) {
+        var server = world.getServer();
+        if (server != null && !server.isOnThread()) {
+            UUID sourceUuid = sourceEntity != null ? sourceEntity.getUuid() : null;
+            server.execute(() -> executeImmediateFeedback(effect, position, world, resolveEntity(world, sourceUuid)));
+            return;
+        }
+
+        executeImmediateFeedback(effect, position, world, sourceEntity);
+    }
+
+    private static void scheduleDelayedFeedback(FeedbackConfig.FeedbackEffect effect, Vec3d position,
+                                                ServerWorld world, Entity sourceEntity) {
+        var server = world.getServer();
+        if (server == null) {
+            return;
+        }
+
+        ensureTickHandlerRegistered();
+
+        UUID sourceUuid = sourceEntity != null ? sourceEntity.getUuid() : null;
+        long executeTick = server.getTicks() + Math.max(1, effect.delayTicks);
+
+        if (server.isOnThread()) {
+            addDelayedTask(world, effect, position, sourceUuid, executeTick);
+        } else {
+            server.execute(() -> addDelayedTask(world, effect, position, sourceUuid, executeTick));
+        }
+    }
+
+    private static void addDelayedTask(ServerWorld world, FeedbackConfig.FeedbackEffect effect, Vec3d position,
+                                       UUID sourceUuid, long executeTick) {
+        var tasks = DELAYED_TASKS.computeIfAbsent(world, key -> new ArrayList<>());
+        tasks.add(new DelayedFeedbackTask(effect, position, sourceUuid, executeTick));
+    }
+
+    private static void ensureTickHandlerRegistered() {
+        if (tickHandlerRegistered) {
+            return;
+        }
+
+        synchronized (FeedbackManager.class) {
+            if (tickHandlerRegistered) {
+                return;
+            }
+            ServerTickEvents.END_WORLD_TICK.register(FeedbackManager::onWorldTick);
+            tickHandlerRegistered = true;
+        }
+    }
+
+    private static void onWorldTick(ServerWorld world) {
+        var tasks = DELAYED_TASKS.get(world);
+        if (tasks == null || tasks.isEmpty()) {
+            return;
+        }
+
+        long currentTick = world.getServer().getTicks();
+        List<DelayedFeedbackTask> dueTasks = new ArrayList<>();
+        for (var task : new ArrayList<>(tasks)) {
+            if (task.executeTick <= currentTick) {
+                dueTasks.add(task);
+            }
+        }
+
+        if (dueTasks.isEmpty()) {
+            return;
+        }
+
+        for (var task : dueTasks) {
+            Entity resolvedSource = resolveEntity(world, task.sourceEntityUuid);
+            executeImmediateFeedback(task.effect, task.position, world, resolvedSource);
+        }
+
+        tasks.removeAll(dueTasks);
+        if (tasks.isEmpty()) {
+            DELAYED_TASKS.remove(world);
+        }
+    }
+
+    private static Entity resolveEntity(ServerWorld world, UUID uuid) {
+        return uuid != null ? world.getEntity(uuid) : null;
+    }
+
+    private static final class DelayedFeedbackTask {
+        private final FeedbackConfig.FeedbackEffect effect;
+        private final Vec3d position;
+        private final UUID sourceEntityUuid;
+        private final long executeTick;
+
+        private DelayedFeedbackTask(FeedbackConfig.FeedbackEffect effect, Vec3d position,
+                                    UUID sourceEntityUuid, long executeTick) {
+            this.effect = effect;
+            this.position = position;
+            this.sourceEntityUuid = sourceEntityUuid;
+            this.executeTick = executeTick;
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the async sleep-based delay in `FeedbackManager` with a tick-based queue processed on the server thread
- run immediate feedback through the server executor when invoked off-thread to keep all world interactions on the main thread

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d2f208b684832faaa45836470ccb8e