### PR TITLE
Optimize mood config caching and weight lookups

### DIFF
--- a/src/main/java/woflo/petsplus/config/PetsPlusConfig.java
+++ b/src/main/java/woflo/petsplus/config/PetsPlusConfig.java
@@ -63,6 +63,7 @@ public class PetsPlusConfig {
     private static PetsPlusConfig instance;
 
     private JsonObject config;
+    private volatile int configGeneration;
     private final Set<String> legacyScopeWarnings = new HashSet<>();
 
     private PetsPlusConfig() {
@@ -110,6 +111,8 @@ public class PetsPlusConfig {
         config.add(ROLES_KEY, rolesObject);
 
         validateOverrides();
+
+        configGeneration++;
     }
 
     private LoadResult readJsonObject(Path path, String description) {
@@ -588,6 +591,10 @@ public class PetsPlusConfig {
     public JsonObject getSection(String key) {
         JsonObject section = getObject(config, key);
         return section != null ? section : EMPTY_OBJECT;
+    }
+
+    public int getConfigGeneration() {
+        return configGeneration;
     }
 
     public JsonObject getRoleOverrides(Identifier roleId) {


### PR DESCRIPTION
## Summary
- track configuration generations in `PetsPlusConfig` so clients can reuse parsed sections after reloads
- cache mood configuration values and emotion-to-mood weights inside `PetMoodEngine`, including precomputed defaults to avoid per-tick allocations

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d3d0fdf1c0832fa22edb3ec49cd19b