### PR TITLE
Align mood enum order with README

### DIFF
--- a/src/main/java/woflo/petsplus/state/PetComponent.java
+++ b/src/main/java/woflo/petsplus/state/PetComponent.java
@@ -57,19 +57,19 @@ public class PetComponent {
      */
     public enum Mood {
         JOYFUL(PetMood.JOYFUL),
-        FEARFUL(PetMood.FEARFUL),
-        WRATHFUL(PetMood.WRATHFUL),
-        SAUDADE(PetMood.SAUDADE),
+        PLAYFUL(PetMood.PLAYFUL),
+        CURIOUS(PetMood.CURIOUS),
+        BONDED(PetMood.BONDED),
         ZEN(PetMood.ZEN),
         ZEALOUS(PetMood.ZEALOUS),
         YUGEN(PetMood.YUGEN),
         TARAB(PetMood.TARAB),
         KINTSUGI(PetMood.KINTSUGI),
-        PLAYFUL(PetMood.PLAYFUL),
-        CURIOUS(PetMood.CURIOUS),
+        SAUDADE(PetMood.SAUDADE),
         PROTECTIVE(PetMood.PROTECTIVE),
-        BONDED(PetMood.BONDED),
-        RESTLESS(PetMood.RESTLESS);
+        RESTLESS(PetMood.RESTLESS),
+        FEARFUL(PetMood.FEARFUL),
+        WRATHFUL(PetMood.WRATHFUL);
 
         public final Formatting primaryFormatting;
         public final Formatting secondaryFormatting;

--- a/src/main/java/woflo/petsplus/state/PetMood.java
+++ b/src/main/java/woflo/petsplus/state/PetMood.java
@@ -7,20 +7,20 @@ import net.minecraft.util.Formatting;
  * PetComponent.Mood wraps these values for backward compatibility.
  */
 public enum PetMood {
-    JOYFUL(Formatting.GOLD, Formatting.YELLOW),           // Happy - bright gold
-    FEARFUL(Formatting.DARK_RED, Formatting.RED),         // Scared - dark to bright red
-    WRATHFUL(Formatting.RED, Formatting.DARK_RED),        // Angry - intense red
-    SAUDADE(Formatting.DARK_BLUE, Formatting.BLUE),       // Melancholic longing - deep blues
-    ZEN(Formatting.GREEN, Formatting.DARK_GREEN),         // Calm - natural greens
-    ZEALOUS(Formatting.RED, Formatting.YELLOW),           // Passionate energy - fire colors
+    JOYFUL(Formatting.GOLD, Formatting.YELLOW),            // Happy - bright gold
+    PLAYFUL(Formatting.YELLOW, Formatting.GREEN),          // Fun energy - bright, lively
+    CURIOUS(Formatting.AQUA, Formatting.WHITE),            // Wonder, exploration - bright, questioning
+    BONDED(Formatting.DARK_AQUA, Formatting.AQUA),         // Deep connection - trust colors
+    ZEN(Formatting.GREEN, Formatting.DARK_GREEN),          // Calm - natural greens
+    ZEALOUS(Formatting.RED, Formatting.YELLOW),            // Passionate energy - fire colors
     YUGEN(Formatting.DARK_PURPLE, Formatting.LIGHT_PURPLE), // Mysterious beauty - purples
-    TARAB(Formatting.LIGHT_PURPLE, Formatting.GOLD),      // Musical ecstasy - purple to gold
-    KINTSUGI(Formatting.WHITE, Formatting.GOLD),          // Beautiful repair - precious metals
-    PLAYFUL(Formatting.YELLOW, Formatting.GREEN),         // Fun energy - bright, lively
-    CURIOUS(Formatting.AQUA, Formatting.WHITE),           // Wonder, exploration - bright, questioning
-    PROTECTIVE(Formatting.BLUE, Formatting.GRAY),         // Steady guardian - reliable blues
-    BONDED(Formatting.DARK_AQUA, Formatting.AQUA),       // Deep connection - trust colors
-    RESTLESS(Formatting.YELLOW, Formatting.RED);          // Agitated energy - hot, moving colors
+    TARAB(Formatting.LIGHT_PURPLE, Formatting.GOLD),       // Musical ecstasy - purple to gold
+    KINTSUGI(Formatting.WHITE, Formatting.GOLD),           // Beautiful repair - precious metals
+    SAUDADE(Formatting.DARK_BLUE, Formatting.BLUE),        // Melancholic longing - deep blues
+    PROTECTIVE(Formatting.BLUE, Formatting.GRAY),          // Steady guardian - reliable blues
+    RESTLESS(Formatting.YELLOW, Formatting.RED),           // Agitated energy - hot, moving colors
+    FEARFUL(Formatting.DARK_RED, Formatting.RED),          // Scared - dark to bright red
+    WRATHFUL(Formatting.RED, Formatting.DARK_RED);         // Angry - intense red
 
     public final Formatting primaryFormatting;
     public final Formatting secondaryFormatting;


### PR DESCRIPTION
## Summary
- reorder the PetMood enum to follow the updated README core mood ordering
- mirror the same ordering in PetComponent.Mood so both enums remain consistent

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d3d8b85ba8832fa17d4e33b656f6dd