### PR TITLE
Add restlessness buildup from chip damage

### DIFF
--- a/src/main/java/woflo/petsplus/events/CombatEventHandler.java
+++ b/src/main/java/woflo/petsplus/events/CombatEventHandler.java
@@ -288,6 +288,17 @@ public class CombatEventHandler {
         float maxHealth = pet.getMaxHealth();
         float damageRatio = Math.min(1.0f, amount / maxHealth);
 
+        // Chip damage should agitate pets over time - build restlessness from repeated light hits
+        float restlessnessAmount = damageRatio * 0.25f;
+        if (damageRatio <= 0.35f) {
+            float lightDamageBonus = (0.35f - damageRatio) / 0.35f;
+            restlessnessAmount += 0.05f + lightDamageBonus * 0.15f;
+        }
+        restlessnessAmount = Math.min(0.6f, restlessnessAmount);
+        if (restlessnessAmount > 0f) {
+            petComponent.pushEmotion(PetComponent.Emotion.AMAL, restlessnessAmount);
+        }
+
         Entity attacker = damageSource.getAttacker();
         PlayerEntity owner = petComponent.getOwner();
 


### PR DESCRIPTION
## Summary
- build restlessness when pets take repeated light hits by feeding AMAL emotion to the mood engine

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d3d9f131b8832f936ffbfb804ffa15