### PR TITLE
Implement bond-aware buffering for pet emotions

### DIFF
--- a/src/main/java/woflo/petsplus/events/PettingHandler.java
+++ b/src/main/java/woflo/petsplus/events/PettingHandler.java
@@ -26,9 +26,6 @@ import woflo.petsplus.ui.FeedbackManager;
  */
 public class PettingHandler {
 
-    private static final String LAST_PET_TIME_KEY = "last_pet_time";
-    private static final String PET_COUNT_KEY = "pet_count";
-
     public static void register() {
         UseEntityCallback.EVENT.register(PettingHandler::onUseEntity);
         Petsplus.LOGGER.info("Petting interaction handler registered");
@@ -61,7 +58,7 @@ public class PettingHandler {
         PetsPlusConfig config = PetsPlusConfig.getInstance();
         int cooldownTicks = config.getPettingCooldownTicks();
         
-        Long lastPetTime = petComp.getStateData(LAST_PET_TIME_KEY, Long.class);
+        Long lastPetTime = petComp.getStateData(PetComponent.StateKeys.LAST_PET_TIME, Long.class);
         if (lastPetTime != null && (currentTime - lastPetTime) < cooldownTicks) {
             // Still on cooldown, but provide subtle feedback
             player.sendMessage(Text.literal("Your companion is still enjoying the last pets"), true);
@@ -79,10 +76,10 @@ public class PettingHandler {
         Identifier roleId = petComp.getRoleId();
 
         // Update petting state
-        petComp.setStateData(LAST_PET_TIME_KEY, currentTime);
-        Integer currentCount = petComp.getStateData(PET_COUNT_KEY, Integer.class);
+        petComp.setStateData(PetComponent.StateKeys.LAST_PET_TIME, currentTime);
+        Integer currentCount = petComp.getStateData(PetComponent.StateKeys.PET_COUNT, Integer.class);
         int newCount = (currentCount == null ? 0 : currentCount) + 1;
-        petComp.setStateData(PET_COUNT_KEY, newCount);
+        petComp.setStateData(PetComponent.StateKeys.PET_COUNT, newCount);
 
         // Base petting effects
         emitBasePettingEffects(player, pet, world, newCount);

--- a/src/main/java/woflo/petsplus/mood/providers/CombatThreatProvider.java
+++ b/src/main/java/woflo/petsplus/mood/providers/CombatThreatProvider.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.registry.tag.EntityTypeTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.Box;
+import net.minecraft.util.math.MathHelper;
 import woflo.petsplus.api.mood.EmotionProvider;
 import woflo.petsplus.api.mood.MoodAPI;
 import woflo.petsplus.state.OwnerCombatState;
@@ -20,28 +21,104 @@ public class CombatThreatProvider implements EmotionProvider {
     @Override public String id() { return "combat_threat"; }
     @Override public int periodHintTicks() { return 20; } // ~1s
 
+    private static final int HABITUATION_WINDOW = 200; // 10s of shared context
+    private static final int MEMORY_FADE_TICKS = 400;   // 20s before streaks soften
+
     @Override
     public void contribute(ServerWorld world, MobEntity pet, PetComponent comp, long time, MoodAPI api) {
-        // Nearby hostiles (cheap AABB query)
+        float resilience = comp.computeBondResilience(time);
+
         Box box = pet.getBoundingBox().expand(8.0);
-        var hostiles = world.getEntitiesByClass(LivingEntity.class, box, e -> e.getType().isIn(EntityTypeTags.RAIDERS) || e.getType().isIn(EntityTypeTags.SKELETONS) || e.getType().isIn(EntityTypeTags.ZOMBIES));
-        if (!hostiles.isEmpty()) {
-            api.pushEmotion(pet, PetComponent.Emotion.ANGST, Math.min(0.05f * hostiles.size(), 0.15f));
+        var hostiles = world.getEntitiesByClass(LivingEntity.class, box, e ->
+            e.getType().isIn(EntityTypeTags.RAIDERS)
+                || e.getType().isIn(EntityTypeTags.SKELETONS)
+                || e.getType().isIn(EntityTypeTags.ZOMBIES));
+
+        int hostileCount = hostiles.size();
+        boolean hasHostiles = hostileCount > 0;
+
+        long lastThreatTick = comp.getStateData(PetComponent.StateKeys.THREAT_LAST_TICK, Long.class, Long.MIN_VALUE);
+        int safeStreak = comp.getStateData(PetComponent.StateKeys.THREAT_SAFE_STREAK, Integer.class, 0);
+        int sensitizedStreak = comp.getStateData(PetComponent.StateKeys.THREAT_SENSITIZED_STREAK, Integer.class, 0);
+        boolean lastEncounterDanger = comp.getStateData(PetComponent.StateKeys.THREAT_LAST_DANGER, Boolean.class, Boolean.FALSE);
+        long lastRecoveryTick = comp.getStateData(PetComponent.StateKeys.THREAT_LAST_RECOVERY_TICK, Long.class, 0L);
+
+        var owner = comp.getOwner();
+        OwnerCombatState ocs = owner != null ? OwnerCombatState.get(owner) : null;
+        boolean ownerDamaged = ocs != null && ocs.recentlyDamaged(time, 60);
+        if (ownerDamaged) {
+            float protectiveness = 0.06f * (0.75f + 0.5f * resilience);
+            api.pushEmotion(pet, PetComponent.Emotion.PROTECTIVENESS, protectiveness);
         }
 
-        // Owner recent damage?
-        var owner = comp.getOwner();
-        if (owner != null) {
-            OwnerCombatState ocs = OwnerCombatState.get(owner);
-            if (ocs != null && ocs.recentlyDamaged(time, 60)) {
-                api.pushEmotion(pet, PetComponent.Emotion.PROTECTIVENESS, 0.06f);
+        boolean petRecentlyHurt = pet.hurtTime > 0;
+
+        if (hasHostiles) {
+            boolean contiguous = lastThreatTick != Long.MIN_VALUE && (time - lastThreatTick) <= HABITUATION_WINDOW;
+            boolean danger = ownerDamaged || petRecentlyHurt;
+
+            if (danger) {
+                sensitizedStreak = contiguous ? Math.min(sensitizedStreak + 1, 5) : 1;
+                safeStreak = 0;
+            } else {
+                safeStreak = contiguous ? Math.min(safeStreak + 1, 5) : 1;
+                if (!contiguous && sensitizedStreak > 0) {
+                    sensitizedStreak = Math.max(0, sensitizedStreak - 1);
+                }
+            }
+
+            float angstPush = Math.min(0.05f * hostileCount, 0.15f);
+            if (danger) {
+                float amp = 1f + 0.15f * sensitizedStreak;
+                angstPush *= MathHelper.clamp(amp, 1f, 1.6f);
+            } else {
+                float damp = 1f - (0.12f * safeStreak) - (0.1f * resilience);
+                angstPush *= MathHelper.clamp(damp, 0.35f, 1f);
+            }
+            api.pushEmotion(pet, PetComponent.Emotion.ANGST, angstPush);
+
+            if (!danger && safeStreak > 0) {
+                float bleed = Math.min(angstPush, (0.025f + 0.015f * safeStreak) * resilience);
+                api.pushEmotion(pet, PetComponent.Emotion.ANGST, -bleed);
+                api.pushEmotion(pet, PetComponent.Emotion.STARTLE, -bleed * 0.7f);
+                api.pushEmotion(pet, PetComponent.Emotion.RELIEF, bleed * 0.6f);
+            }
+
+            comp.setStateData(PetComponent.StateKeys.THREAT_SAFE_STREAK, safeStreak);
+            comp.setStateData(PetComponent.StateKeys.THREAT_SENSITIZED_STREAK, sensitizedStreak);
+            comp.setStateData(PetComponent.StateKeys.THREAT_LAST_TICK, time);
+            comp.setStateData(PetComponent.StateKeys.THREAT_LAST_DANGER, danger);
+        } else {
+            if (lastThreatTick != Long.MIN_VALUE) {
+                long sinceLast = time - lastThreatTick;
+                if (!lastEncounterDanger && sinceLast <= 120 && (time - lastRecoveryTick) > 80) {
+                    float relief = (0.02f + 0.01f * safeStreak) * resilience;
+                    api.pushEmotion(pet, PetComponent.Emotion.RELIEF, relief);
+                    api.pushEmotion(pet, PetComponent.Emotion.LAGOM, relief * 0.5f);
+                    comp.setStateData(PetComponent.StateKeys.THREAT_LAST_RECOVERY_TICK, time);
+                }
+
+                if (sinceLast > MEMORY_FADE_TICKS) {
+                    if (safeStreak > 0) {
+                        safeStreak = Math.max(0, safeStreak - 1);
+                        comp.setStateData(PetComponent.StateKeys.THREAT_SAFE_STREAK, safeStreak);
+                    }
+                    if (sensitizedStreak > 0) {
+                        sensitizedStreak = Math.max(0, sensitizedStreak - 1);
+                        comp.setStateData(PetComponent.StateKeys.THREAT_SENSITIZED_STREAK, sensitizedStreak);
+                    }
+                    if (sinceLast > MEMORY_FADE_TICKS * 2L) {
+                        comp.setStateData(PetComponent.StateKeys.THREAT_LAST_TICK, Long.MIN_VALUE);
+                        comp.setStateData(PetComponent.StateKeys.THREAT_LAST_DANGER, false);
+                    }
+                }
             }
         }
 
-        // Pet hurt recently check via entity's hurt time (simple signal)
-        if (pet.hurtTime > 0) {
-            api.pushEmotion(pet, PetComponent.Emotion.STARTLE, 0.04f);
-            api.pushEmotion(pet, PetComponent.Emotion.FRUSTRATION, 0.02f);
+        if (petRecentlyHurt) {
+            float harmAmp = 1f + 0.1f * MathHelper.clamp(sensitizedStreak, 0, 5);
+            api.pushEmotion(pet, PetComponent.Emotion.STARTLE, 0.04f * harmAmp);
+            api.pushEmotion(pet, PetComponent.Emotion.FRUSTRATION, 0.02f * harmAmp);
         }
     }
 }

--- a/src/main/java/woflo/petsplus/mood/providers/EnvironmentComfortProvider.java
+++ b/src/main/java/woflo/petsplus/mood/providers/EnvironmentComfortProvider.java
@@ -27,6 +27,7 @@ public class EnvironmentComfortProvider implements EmotionProvider {
             double d2 = pet.squaredDistanceTo(owner);
             if (d2 < 36) { // within 6 blocks
                 api.pushEmotion(pet, PetComponent.Emotion.QUERECIA, 0.05f);
+                applySocialBuffer(comp, pet, time, api);
             }
         }
 
@@ -60,5 +61,31 @@ public class EnvironmentComfortProvider implements EmotionProvider {
         if (world.isRaining() && world.isSkyVisible(pet.getBlockPos().up())) {
             api.pushEmotion(pet, PetComponent.Emotion.FOREBODING, 0.02f);
         }
+    }
+
+    private void applySocialBuffer(PetComponent comp, MobEntity pet, long now, MoodAPI api) {
+        boolean stressed = comp.hasMoodAbove(PetComponent.Mood.AFRAID, 0.25f)
+            || comp.hasMoodAbove(PetComponent.Mood.RESTLESS, 0.3f)
+            || comp.hasMoodAbove(PetComponent.Mood.ANGRY, 0.3f);
+        if (!stressed) {
+            return;
+        }
+
+        long lastTick = comp.getStateData(PetComponent.StateKeys.LAST_SOCIAL_BUFFER_TICK, Long.class, 0L);
+        if (now - lastTick < 60) {
+            return; // leave a short window so we do not over-dampen
+        }
+
+        float resilience = comp.computeBondResilience(now);
+        float calmDrain = Math.min(0.1f, 0.03f + 0.05f * resilience);
+        api.pushEmotion(pet, PetComponent.Emotion.ANGST, -calmDrain);
+        api.pushEmotion(pet, PetComponent.Emotion.STARTLE, -calmDrain * 0.6f);
+        api.pushEmotion(pet, PetComponent.Emotion.FRUSTRATION, -calmDrain * 0.4f);
+
+        float reassurance = 0.02f + 0.03f * resilience;
+        api.pushEmotion(pet, PetComponent.Emotion.RELIEF, reassurance);
+        api.pushEmotion(pet, PetComponent.Emotion.UBUNTU, reassurance * 0.6f);
+
+        comp.setStateData(PetComponent.StateKeys.LAST_SOCIAL_BUFFER_TICK, now);
     }
 }


### PR DESCRIPTION
## Summary
- add reusable state-data keys plus tame tick and bond resilience helpers to `PetComponent`
- switch petting interaction bookkeeping to the shared state keys and preserve tame metadata on resets
- extend the environment and combat emotion providers with bond-weighted social buffering and habituation/sensitization logic

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d409716b5c832f8b51c4de2a220fab