### PR TITLE
Implement owner ability trigger tracker and crouch cuddle goal

### DIFF
--- a/src/main/java/woflo/petsplus/ai/PetAIEnhancements.java
+++ b/src/main/java/woflo/petsplus/ai/PetAIEnhancements.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.passive.TameableEntity;
 import woflo.petsplus.state.PetComponent;
 import woflo.petsplus.Petsplus;
 import woflo.petsplus.mixin.MobEntityAccessor;
+import woflo.petsplus.ai.goals.CrouchCuddleGoal;
 import woflo.petsplus.ai.goals.EnhancedFollowOwnerGoal;
 
 /**
@@ -24,6 +25,9 @@ public class PetAIEnhancements {
         try {
             // Enhanced follow behavior for all pets
             addEnhancedFollowGoal(pet, petComponent);
+
+            // Crouch cuddle handshake keeps pets cozy near crouching owners
+            addCrouchCuddleGoal(pet, petComponent);
             
             // Improved pathfinding penalties
             adjustPathfindingPenalties(pet, petComponent);
@@ -50,7 +54,7 @@ public class PetAIEnhancements {
      */
     private static void addEnhancedFollowGoal(MobEntity pet, PetComponent petComponent) {
         if (!(pet instanceof TameableEntity tameable)) return;
-        
+
         MobEntityAccessor accessor = (MobEntityAccessor) pet;
         
         // Remove existing follow goals to replace with enhanced version
@@ -63,6 +67,12 @@ public class PetAIEnhancements {
         
         accessor.getGoalSelector().add(5, new EnhancedFollowOwnerGoal(tameable, 1.0, 
             followDistance, teleportDistance, false));
+    }
+
+    private static void addCrouchCuddleGoal(MobEntity pet, PetComponent petComponent) {
+        MobEntityAccessor accessor = (MobEntityAccessor) pet;
+        accessor.getGoalSelector().getGoals().removeIf(entry -> entry.getGoal() instanceof CrouchCuddleGoal);
+        accessor.getGoalSelector().add(4, new CrouchCuddleGoal(pet, petComponent));
     }
     
     /**

--- a/src/main/java/woflo/petsplus/ai/goals/CrouchCuddleGoal.java
+++ b/src/main/java/woflo/petsplus/ai/goals/CrouchCuddleGoal.java
@@ -1,0 +1,124 @@
+package woflo.petsplus.ai.goals;
+
+import net.minecraft.entity.ai.goal.Goal;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.Vec3d;
+import woflo.petsplus.state.PetComponent;
+
+import java.util.EnumSet;
+import java.util.UUID;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * When a pet enters the crouch cuddle handshake it slows near the owner and
+ * hovers in a tight radius so proximity channels feel intentional and cozy.
+ */
+public class CrouchCuddleGoal extends Goal {
+    private static final double APPROACH_SPEED = 0.5;
+    private static final double HOVER_SPEED = 0.35;
+    private static final double CLOSE_DISTANCE_SQ = 2.25; // ~1.5 blocks
+    private static final double SNUFFLE_DISTANCE_SQ = 0.25; // ~0.5 blocks
+
+    private final MobEntity pet;
+    private final PetComponent component;
+    @Nullable
+    private ServerPlayerEntity cuddleOwner;
+
+    public CrouchCuddleGoal(MobEntity pet, PetComponent component) {
+        this.pet = pet;
+        this.component = component;
+        this.setControls(EnumSet.of(Control.MOVE, Control.LOOK));
+    }
+
+    @Override
+    public boolean canStart() {
+        if (pet.getWorld().isClient) {
+            return false;
+        }
+
+        return refreshCuddleOwner();
+    }
+
+    @Override
+    public boolean shouldContinue() {
+        if (pet.getWorld().isClient) {
+            return false;
+        }
+
+        return refreshCuddleOwner();
+    }
+
+    @Override
+    public void stop() {
+        pet.getNavigation().stop();
+        cuddleOwner = null;
+    }
+
+    @Override
+    public void tick() {
+        ServerPlayerEntity owner = this.cuddleOwner;
+        if (owner == null) {
+            return;
+        }
+
+        double distanceSq = pet.squaredDistanceTo(owner);
+        pet.getLookControl().lookAt(owner, 30.0f, 30.0f);
+
+        if (distanceSq > CLOSE_DISTANCE_SQ) {
+            pet.getNavigation().startMovingTo(owner, APPROACH_SPEED);
+            return;
+        }
+
+        pet.getNavigation().stop();
+
+        if (distanceSq > SNUFFLE_DISTANCE_SQ) {
+            Vec3d ownerPos = owner.getPos();
+            pet.getMoveControl().moveTo(ownerPos.x, ownerPos.y, ownerPos.z, HOVER_SPEED);
+            pet.setVelocity(pet.getVelocity().multiply(0.5, 1.0, 0.5));
+        } else {
+            pet.setVelocity(pet.getVelocity().multiply(0.1, 1.0, 0.1));
+        }
+    }
+
+    private boolean refreshCuddleOwner() {
+        ServerPlayerEntity owner = resolveActiveOwner();
+        if (owner == null) {
+            this.cuddleOwner = null;
+            return false;
+        }
+
+        this.cuddleOwner = owner;
+        return true;
+    }
+
+    @Nullable
+    private ServerPlayerEntity resolveActiveOwner() {
+        if (!(pet.getWorld() instanceof ServerWorld serverWorld)) {
+            return null;
+        }
+
+        UUID ownerId = component.getCrouchCuddleOwnerId();
+        if (ownerId == null) {
+            return null;
+        }
+
+        ServerPlayerEntity owner = serverWorld.getServer().getPlayerManager().getPlayer(ownerId);
+        if (owner == null || owner.isRemoved() || !owner.isAlive() || owner.isSpectator()) {
+            return null;
+        }
+
+        if (owner.getWorld() != serverWorld || !owner.isSneaking()) {
+            return null;
+        }
+
+        long currentTick = serverWorld.getTime();
+        if (!component.isCrouchCuddleActiveWith(owner, currentTick)) {
+            return null;
+        }
+
+        return owner;
+    }
+}

--- a/src/main/java/woflo/petsplus/api/event/OwnerAbilitySignalEvent.java
+++ b/src/main/java/woflo/petsplus/api/event/OwnerAbilitySignalEvent.java
@@ -1,0 +1,45 @@
+package woflo.petsplus.api.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+/**
+ * Fired when an owner successfully performs a manual trigger action targeting their pet.
+ */
+public final class OwnerAbilitySignalEvent {
+    /** Global event hook for owner ability trigger signals. */
+    public static final Event<Listener> EVENT = EventFactory.createArrayBacked(Listener.class,
+        listeners -> (type, owner, pet) -> {
+            for (Listener listener : listeners) {
+                listener.onSignal(type, owner, pet);
+            }
+        }
+    );
+
+    private OwnerAbilitySignalEvent() {
+    }
+
+    /**
+     * Dispatches the trigger event.
+     */
+    public static void fire(Type type, ServerPlayerEntity owner, MobEntity pet) {
+        EVENT.invoker().onSignal(type, owner, pet);
+    }
+
+    /** Callback for listener registrations. */
+    @FunctionalInterface
+    public interface Listener {
+        /**
+         * Invoked when the owner completes the specified trigger targeting the supplied pet.
+         */
+        void onSignal(Type type, ServerPlayerEntity owner, MobEntity pet);
+    }
+
+    /** Supported manual trigger types. */
+    public enum Type {
+        DOUBLE_CROUCH,
+        PROXIMITY_CHANNEL
+    }
+}

--- a/src/main/java/woflo/petsplus/initialization/InitializationManager.java
+++ b/src/main/java/woflo/petsplus/initialization/InitializationManager.java
@@ -72,7 +72,8 @@ public class InitializationManager {
         woflo.petsplus.events.TributeHandler.register();
         woflo.petsplus.events.PetsplusItemHandler.register();
         woflo.petsplus.events.PettingHandler.register();
-        
+        woflo.petsplus.interaction.OwnerAbilitySignalTracker.register();
+
         // System event handlers
         woflo.petsplus.events.PetDetectionHandler.register();
         woflo.petsplus.events.PlayerStateTracker.register();

--- a/src/main/java/woflo/petsplus/interaction/OwnerAbilitySignalTracker.java
+++ b/src/main/java/woflo/petsplus/interaction/OwnerAbilitySignalTracker.java
@@ -1,0 +1,302 @@
+package woflo.petsplus.interaction;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import woflo.petsplus.Petsplus;
+import woflo.petsplus.api.event.OwnerAbilitySignalEvent;
+import woflo.petsplus.state.PetComponent;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.WeakHashMap;
+
+/**
+ * Detects owner initiated trigger signals (double crouch and proximity channel)
+ * and surfaces them via {@link OwnerAbilitySignalEvent}.
+ */
+public final class OwnerAbilitySignalTracker {
+    private static final long DOUBLE_CROUCH_WINDOW_TICKS = 12;
+    private static final double DOUBLE_CROUCH_MAX_DISTANCE = 16.0;
+    private static final double DOUBLE_CROUCH_ALIGNMENT_THRESHOLD = 0.97;
+    private static final double PROXIMITY_RANGE = 3.0;
+    private static final double PROXIMITY_RANGE_SQ = PROXIMITY_RANGE * PROXIMITY_RANGE;
+    private static final int PROXIMITY_DURATION_TICKS = 30;
+
+    private static final Map<ServerPlayerEntity, SneakState> SNEAK_STATES = new WeakHashMap<>();
+    private static final Map<ServerWorld, Map<MobEntity, ProximityChannel>> ACTIVE_CHANNELS = new WeakHashMap<>();
+
+    private OwnerAbilitySignalTracker() {
+    }
+
+    /**
+     * Registers tick hooks used to process active proximity channels.
+     */
+    public static void register() {
+        ServerTickEvents.END_WORLD_TICK.register(OwnerAbilitySignalTracker::tickWorld);
+        Petsplus.LOGGER.info("Owner ability signal tracker registered");
+    }
+
+    /**
+     * Invoked from mixin when a player's sneaking state changes.
+     */
+    public static void handleSneakToggle(ServerPlayerEntity player, boolean sneaking) {
+        if (player.isSpectator() || player.isRemoved() || !player.isAlive()) {
+            return;
+        }
+
+        SneakState state = SNEAK_STATES.computeIfAbsent(player, ignored -> new SneakState());
+        if (state.sneaking == sneaking) {
+            return;
+        }
+
+        state.sneaking = sneaking;
+        long now = player.getWorld().getTime();
+
+        if (sneaking) {
+            boolean triggeredDouble = false;
+
+            // Double crouch detection (press following a recent release)
+            if (state.lastReleaseTick >= 0
+                && now - state.lastReleaseTick <= DOUBLE_CROUCH_WINDOW_TICKS
+                && state.lastPressTick >= 0
+                && state.lastReleaseTick - state.lastPressTick <= DOUBLE_CROUCH_WINDOW_TICKS) {
+                triggeredDouble = handleDoubleCrouch(player);
+            }
+
+            state.lastPressTick = now;
+
+            if (!triggeredDouble) {
+                startProximityChannels(player);
+            }
+        } else {
+            state.lastReleaseTick = now;
+            cancelProximityChannels(player);
+        }
+    }
+
+    private static boolean handleDoubleCrouch(ServerPlayerEntity player) {
+        MobEntity target = findLookTarget(player);
+        if (target == null) {
+            return false;
+        }
+
+        OwnerAbilitySignalEvent.fire(OwnerAbilitySignalEvent.Type.DOUBLE_CROUCH, player, target);
+        return true;
+    }
+
+    private static MobEntity findLookTarget(ServerPlayerEntity player) {
+        World world = player.getWorld();
+        Vec3d eyePos = player.getCameraPosVec(1.0f);
+        Vec3d lookVec = player.getRotationVec(1.0f);
+        Box searchBox = player.getBoundingBox().stretch(lookVec.multiply(DOUBLE_CROUCH_MAX_DISTANCE)).expand(1.0);
+        double closestDistanceSq = DOUBLE_CROUCH_MAX_DISTANCE * DOUBLE_CROUCH_MAX_DISTANCE;
+        MobEntity closest = null;
+
+        for (Entity entity : world.getOtherEntities(player, searchBox, e -> isOwnedPet(player, e))) {
+            if (!(entity instanceof MobEntity mob)) {
+                continue;
+            }
+
+            double distanceSq = player.squaredDistanceTo(mob);
+            if (distanceSq > closestDistanceSq) {
+                continue;
+            }
+
+            Vec3d toEntity = mob.getBoundingBox().getCenter().subtract(eyePos);
+            double lengthSq = toEntity.lengthSquared();
+            if (lengthSq < 1.0e-4) {
+                continue;
+            }
+
+            double alignment = toEntity.normalize().dotProduct(lookVec);
+            if (alignment < DOUBLE_CROUCH_ALIGNMENT_THRESHOLD) {
+                continue;
+            }
+
+            if (!player.canSee(mob)) {
+                continue;
+            }
+
+            closest = mob;
+            closestDistanceSq = distanceSq;
+        }
+
+        return closest;
+    }
+
+    private static boolean isOwnedPet(ServerPlayerEntity owner, Entity entity) {
+        if (!(entity instanceof MobEntity mob) || entity.isRemoved() || !entity.isAlive()) {
+            return false;
+        }
+
+        PetComponent component = PetComponent.get(mob);
+        if (component == null || !component.isOwnedBy(owner)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static void startProximityChannels(ServerPlayerEntity player) {
+        ServerWorld world = (ServerWorld) player.getWorld();
+        Box search = player.getBoundingBox().expand(PROXIMITY_RANGE, PROXIMITY_RANGE / 2.0, PROXIMITY_RANGE);
+        java.util.List<MobEntity> nearbyPets = world.getEntitiesByClass(
+            MobEntity.class,
+            search,
+            entity -> isOwnedPet(player, entity)
+        );
+
+        if (nearbyPets.isEmpty()) {
+            return;
+        }
+
+        Map<MobEntity, ProximityChannel> worldChannels = ACTIVE_CHANNELS.computeIfAbsent(world, w -> new WeakHashMap<>());
+        long completionTick = world.getTime() + PROXIMITY_DURATION_TICKS;
+        UUID ownerId = player.getUuid();
+
+        for (MobEntity pet : nearbyPets) {
+            PetComponent component = PetComponent.get(pet);
+            if (component == null || component.isPerched()) {
+                continue;
+            }
+
+            ProximityChannel existing = worldChannels.get(pet);
+            if (existing != null && existing.ownerId.equals(ownerId)) {
+                existing.refresh(completionTick);
+                component.refreshCrouchCuddle(ownerId, completionTick);
+                continue;
+            }
+
+            worldChannels.put(pet, new ProximityChannel(ownerId, completionTick));
+            component.beginCrouchCuddle(ownerId, completionTick);
+        }
+    }
+
+    private static void cancelProximityChannels(ServerPlayerEntity player) {
+        ServerWorld world = (ServerWorld) player.getWorld();
+        Map<MobEntity, ProximityChannel> worldChannels = ACTIVE_CHANNELS.get(world);
+        if (worldChannels == null || worldChannels.isEmpty()) {
+            return;
+        }
+
+        UUID ownerId = player.getUuid();
+        Iterator<Map.Entry<MobEntity, ProximityChannel>> iterator = worldChannels.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<MobEntity, ProximityChannel> entry = iterator.next();
+            if (entry.getValue().ownerId.equals(ownerId)) {
+                iterator.remove();
+                PetComponent component = PetComponent.get(entry.getKey());
+                if (component != null) {
+                    component.endCrouchCuddle(ownerId);
+                }
+            }
+        }
+
+        if (worldChannels.isEmpty()) {
+            ACTIVE_CHANNELS.remove(world);
+        }
+    }
+
+    private static void tickWorld(ServerWorld world) {
+        Map<MobEntity, ProximityChannel> worldChannels = ACTIVE_CHANNELS.get(world);
+        if (worldChannels == null || worldChannels.isEmpty()) {
+            return;
+        }
+
+        long now = world.getTime();
+        Iterator<Map.Entry<MobEntity, ProximityChannel>> iterator = worldChannels.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<MobEntity, ProximityChannel> entry = iterator.next();
+            MobEntity pet = entry.getKey();
+            ProximityChannel channel = entry.getValue();
+
+            if (pet == null || !pet.isAlive() || pet.isRemoved()) {
+                PetComponent component = pet != null ? PetComponent.get(pet) : null;
+                if (component != null) {
+                    component.endCrouchCuddle(channel.ownerId);
+                }
+                iterator.remove();
+                continue;
+            }
+
+            ServerPlayerEntity owner = world.getServer().getPlayerManager().getPlayer(channel.ownerId);
+            PetComponent component = PetComponent.get(pet);
+            if (component == null) {
+                iterator.remove();
+                continue;
+            }
+
+            if (component.isPerched()) {
+                component.endCrouchCuddle(channel.ownerId);
+                iterator.remove();
+                continue;
+            }
+
+            if (owner == null || owner.isRemoved() || owner.isSpectator() || owner.getWorld() != world) {
+                component.endCrouchCuddle(channel.ownerId);
+                iterator.remove();
+                continue;
+            }
+
+            if (!owner.isSneaking()) {
+                component.endCrouchCuddle(channel.ownerId);
+                iterator.remove();
+                continue;
+            }
+
+            if (!component.isOwnedBy(owner)) {
+                component.endCrouchCuddle(channel.ownerId);
+                iterator.remove();
+                continue;
+            }
+
+            if (!component.isCrouchCuddleActiveWith(owner, now)) {
+                component.endCrouchCuddle(channel.ownerId);
+                iterator.remove();
+                continue;
+            }
+
+            if (owner.squaredDistanceTo(pet) > PROXIMITY_RANGE_SQ) {
+                component.endCrouchCuddle(channel.ownerId);
+                iterator.remove();
+                continue;
+            }
+
+            if (now >= channel.completionTick) {
+                iterator.remove();
+                component.endCrouchCuddle(channel.ownerId);
+                OwnerAbilitySignalEvent.fire(OwnerAbilitySignalEvent.Type.PROXIMITY_CHANNEL, owner, pet);
+            }
+        }
+
+        if (worldChannels.isEmpty()) {
+            ACTIVE_CHANNELS.remove(world);
+        }
+    }
+
+    private static final class SneakState {
+        private boolean sneaking;
+        private long lastPressTick = -1;
+        private long lastReleaseTick = -1;
+    }
+
+    private static final class ProximityChannel {
+        private final UUID ownerId;
+        private long completionTick;
+
+        private ProximityChannel(UUID ownerId, long completionTick) {
+            this.ownerId = ownerId;
+            this.completionTick = completionTick;
+        }
+
+        private void refresh(long newCompletionTick) {
+            this.completionTick = Math.max(this.completionTick, newCompletionTick);
+        }
+    }
+}

--- a/src/main/java/woflo/petsplus/mixin/EntitySneakMixin.java
+++ b/src/main/java/woflo/petsplus/mixin/EntitySneakMixin.java
@@ -1,0 +1,23 @@
+package woflo.petsplus.mixin;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import woflo.petsplus.interaction.OwnerAbilitySignalTracker;
+
+/**
+ * Hooks into sneaking state changes to detect manual trigger inputs without per-tick polling.
+ */
+@Mixin(Entity.class)
+public abstract class EntitySneakMixin {
+    @Inject(method = "setSneaking", at = @At("TAIL"))
+    private void petsplus$handleSneakToggle(boolean sneaking, CallbackInfo ci) {
+        Entity self = (Entity) (Object) this;
+        if (self instanceof ServerPlayerEntity serverPlayer) {
+            OwnerAbilitySignalTracker.handleSneakToggle(serverPlayer, sneaking);
+        }
+    }
+}

--- a/src/main/resources/petsplus.mixins.json
+++ b/src/main/resources/petsplus.mixins.json
@@ -7,8 +7,9 @@
 		"PlayerAttackMixin",
 		"TameableEntityMixin",
 		"MobEntityDataMixin",
-		"MobEntityAccessor"
-	],
+                "MobEntityAccessor",
+                "EntitySneakMixin"
+        ],
 	"client": [
 	],
 	"injectors": {


### PR DESCRIPTION
## Summary
- introduce `OwnerAbilitySignalEvent` and associated tracker so manual pet ability signals fire on double crouch and 1.5s proximity channels
- add a server-side crouch cuddle AI goal that keeps pets hovering near sneaking owners while the handshake is active
- hook the sneaking mixin and initialization flow so every pet can surface trigger events without per-tick polling

## Testing
- ./gradlew build
