### PR TITLE
Bridge owner ability signals into trigger contexts

### DIFF
--- a/src/main/java/woflo/petsplus/api/registry/PetsPlusRegistries.java
+++ b/src/main/java/woflo/petsplus/api/registry/PetsPlusRegistries.java
@@ -286,6 +286,16 @@ public final class PetsPlusRegistries {
             .description("Triggered when the pet exits combat.")
             .build());
 
+        registerTriggerSerializer(TriggerSerializer.builder(id("owner_signal_double_crouch"), CooldownSettings.CODEC,
+            (abilityId, config) -> DataResult.success(simpleEventTrigger("owner_signal_double_crouch", config.resolvedCooldown())))
+            .description("Fires when the owner performs the double crouch manual trigger on their pet.")
+            .build());
+
+        registerTriggerSerializer(TriggerSerializer.builder(id("owner_signal_proximity_channel"), CooldownSettings.CODEC,
+            (abilityId, config) -> DataResult.success(simpleEventTrigger("owner_signal_proximity_channel", config.resolvedCooldown())))
+            .description("Fires when the owner completes the crouch-and-hold proximity channel with their pet.")
+            .build());
+
         registerTriggerSerializer(TriggerSerializer.builder(id("owner_low_health"), OwnerLowHealthConfig.CODEC,
             (abilityId, config) -> DataResult.success(new Trigger() {
                 private final Identifier triggerId = id("owner_low_health");

--- a/src/main/java/woflo/petsplus/initialization/InitializationManager.java
+++ b/src/main/java/woflo/petsplus/initialization/InitializationManager.java
@@ -73,6 +73,7 @@ public class InitializationManager {
         woflo.petsplus.events.PetsplusItemHandler.register();
         woflo.petsplus.events.PettingHandler.register();
         woflo.petsplus.interaction.OwnerAbilitySignalTracker.register();
+        woflo.petsplus.interaction.OwnerAbilitySignalAbilityBridge.register();
 
         // System event handlers
         woflo.petsplus.events.PetDetectionHandler.register();

--- a/src/main/java/woflo/petsplus/interaction/OwnerAbilitySignalAbilityBridge.java
+++ b/src/main/java/woflo/petsplus/interaction/OwnerAbilitySignalAbilityBridge.java
@@ -1,0 +1,46 @@
+package woflo.petsplus.interaction;
+
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import woflo.petsplus.abilities.AbilityManager;
+import woflo.petsplus.api.TriggerContext;
+import woflo.petsplus.api.event.OwnerAbilitySignalEvent;
+
+/**
+ * Bridges manual owner ability signals into the shared ability trigger pipeline.
+ */
+public final class OwnerAbilitySignalAbilityBridge {
+    private static final String DOUBLE_CROUCH_EVENT = "owner_signal_double_crouch";
+    private static final String PROXIMITY_EVENT = "owner_signal_proximity_channel";
+
+    private OwnerAbilitySignalAbilityBridge() {
+    }
+
+    /** Registers the bridge listener. */
+    public static void register() {
+        OwnerAbilitySignalEvent.EVENT.register(OwnerAbilitySignalAbilityBridge::handleSignal);
+    }
+
+    private static void handleSignal(OwnerAbilitySignalEvent.Type type, ServerPlayerEntity owner, MobEntity pet) {
+        if (owner == null || pet == null) {
+            return;
+        }
+
+        ServerWorld world = (ServerWorld) owner.getWorld();
+        String eventType = mapEventType(type);
+        if (eventType == null) {
+            return;
+        }
+
+        TriggerContext context = new TriggerContext(world, pet, owner, eventType);
+        AbilityManager.triggerAbilities(pet, context);
+    }
+
+    private static String mapEventType(OwnerAbilitySignalEvent.Type type) {
+        return switch (type) {
+            case DOUBLE_CROUCH -> DOUBLE_CROUCH_EVENT;
+            case PROXIMITY_CHANNEL -> PROXIMITY_EVENT;
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- bridge OwnerAbilitySignalEvent into the ability runtime so manual inputs dispatch TriggerContexts to the targeted pet
- register trigger serializers for owner_signal_double_crouch and owner_signal_proximity_channel so datapacks can consume the new events

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d5689e5b6c832fbc7d42155f6a01e3