### PR TITLE
Use glass panes for scout backpack toggle

### DIFF
--- a/src/main/java/woflo/petsplus/api/registry/PetsPlusRegistries.java
+++ b/src/main/java/woflo/petsplus/api/registry/PetsPlusRegistries.java
@@ -26,6 +26,8 @@ import woflo.petsplus.effects.HealOwnerFlatPctEffect;
 import woflo.petsplus.effects.KnockupEffect;
 import woflo.petsplus.effects.MagnetizeDropsAndXpEffect;
 import woflo.petsplus.effects.MountedConeAuraEffect;
+import woflo.petsplus.effects.OpenEnderChestEffect;
+import woflo.petsplus.effects.OpenPetBackpackEffect;
 import woflo.petsplus.effects.OwnerNextAttackBonusEffect;
 import woflo.petsplus.effects.PerchPotionSipReductionEffect;
 import woflo.petsplus.effects.ProjectileDrForOwnerEffect;
@@ -392,6 +394,16 @@ public final class PetsPlusRegistries {
             .description("Pulls item drops and XP orbs toward the pet.")
             .build());
 
+        registerEffectSerializer(EffectSerializer.builder(id("open_ender_chest"), RegistryJsonHelper.JSON_OBJECT_CODEC,
+            (abilityId, json, context) -> DataResult.success(new OpenEnderChestEffect()))
+            .description("Opens the owner's ender chest.")
+            .build());
+
+        registerEffectSerializer(EffectSerializer.builder(id("open_pet_backpack"), RegistryJsonHelper.JSON_OBJECT_CODEC,
+            (abilityId, json, context) -> DataResult.success(new OpenPetBackpackEffect()))
+            .description("Opens the pet's persistent backpack inventory.")
+            .build());
+
         registerEffectSerializer(EffectSerializer.builder(id("area_effect"), RegistryJsonHelper.JSON_OBJECT_CODEC,
             (abilityId, json, context) -> DataResult.success(new AreaEffectEffect(json)))
             .description("Executes nested effects over an area.")
@@ -453,6 +465,8 @@ public final class PetsPlusRegistries {
         registerAbilityType("nap_time_radius", createPlaceholderAbility("nap_time_radius"));
         registerAbilityType("event_horizon", createPlaceholderAbility("event_horizon"));
         registerAbilityType("edge_step", createPlaceholderAbility("edge_step"));
+        registerAbilityType("void_storage", createPlaceholderAbility("void_storage"));
+        registerAbilityType("scout_backpack", createPlaceholderAbility("scout_backpack"));
     }
 
     private static AbilityType createPlaceholderAbility(String name) {

--- a/src/main/java/woflo/petsplus/datagen/SimpleDataGenerator.java
+++ b/src/main/java/woflo/petsplus/datagen/SimpleDataGenerator.java
@@ -53,6 +53,7 @@ public class SimpleDataGenerator {
 
         // Scout abilities
         writeFile("abilities/loot_wisp.json", createLootWisp());
+        writeFile("abilities/scout_backpack.json", createScoutBackpack());
 
         // Skyrider abilities
         writeFile("abilities/windlash_rider.json", createWindlashRider());
@@ -62,6 +63,7 @@ public class SimpleDataGenerator {
 
         // Eclipsed abilities
         writeFile("abilities/voidbrand.json", createVoidbrand());
+        writeFile("abilities/void_storage.json", createVoidStorage());
         writeFile("abilities/phase_partner.json", createPhasePartner());
         writeFile("abilities/perch_ping.json", createPerchPing());
     }
@@ -172,7 +174,7 @@ public class SimpleDataGenerator {
     private static JsonObject createLootWisp() {
         JsonObject ability = new JsonObject();
         ability.addProperty("id", "petsplus:loot_wisp");
-        
+
         JsonObject trigger = new JsonObject();
         trigger.addProperty("event", "on_combat_end");
         trigger.addProperty("cooldown_ticks", 200);
@@ -188,11 +190,30 @@ public class SimpleDataGenerator {
         ability.add("effects", effects);
         return ability;
     }
-    
+
+    private static JsonObject createScoutBackpack() {
+        JsonObject ability = new JsonObject();
+        ability.addProperty("id", "petsplus:scout_backpack");
+
+        JsonObject trigger = new JsonObject();
+        trigger.addProperty("event", "owner_signal_proximity_channel");
+        trigger.addProperty("cooldown_ticks", 40);
+        ability.add("trigger", trigger);
+
+        JsonArray effects = new JsonArray();
+        JsonObject openBackpack = new JsonObject();
+        openBackpack.addProperty("type", "open_pet_backpack");
+        effects.add(openBackpack);
+
+        ability.add("effects", effects);
+        ability.addProperty("required_level", 5);
+        return ability;
+    }
+
     private static JsonObject createWindlashRider() {
         JsonObject ability = new JsonObject();
         ability.addProperty("id", "petsplus:windlash_rider");
-        
+
         JsonObject trigger = new JsonObject();
         trigger.addProperty("event", "owner_begin_fall");
         trigger.addProperty("min_fall", 3);
@@ -280,7 +301,7 @@ public class SimpleDataGenerator {
     private static JsonObject createVoidbrand() {
         JsonObject ability = new JsonObject();
         ability.addProperty("id", "petsplus:voidbrand");
-        
+
         JsonObject trigger = new JsonObject();
         trigger.addProperty("event", "aggro_acquired");
         trigger.addProperty("cooldown_ticks", 300);
@@ -314,7 +335,26 @@ public class SimpleDataGenerator {
         ability.add("effects", effects);
         return ability;
     }
-    
+
+    private static JsonObject createVoidStorage() {
+        JsonObject ability = new JsonObject();
+        ability.addProperty("id", "petsplus:void_storage");
+        ability.addProperty("required_level", 7);
+
+        JsonObject trigger = new JsonObject();
+        trigger.addProperty("event", "owner_signal_proximity_channel");
+        trigger.addProperty("cooldown_ticks", 120);
+        ability.add("trigger", trigger);
+
+        JsonArray effects = new JsonArray();
+        JsonObject openEnderChest = new JsonObject();
+        openEnderChest.addProperty("type", "open_ender_chest");
+        effects.add(openEnderChest);
+
+        ability.add("effects", effects);
+        return ability;
+    }
+
     private static JsonObject createPhasePartner() {
         JsonObject ability = new JsonObject();
         ability.addProperty("id", "petsplus:phase_partner");
@@ -481,11 +521,12 @@ public class SimpleDataGenerator {
         JsonObject role = new JsonObject();
         role.addProperty("name", "Scout");
         role.addProperty("description", "Information gathering and mobility for everyone");
-        
+
         JsonArray abilities = new JsonArray();
         abilities.add("petsplus:spotter_fallback");
         abilities.add("petsplus:gale_pace");
         abilities.add("petsplus:loot_wisp");
+        abilities.add("petsplus:scout_backpack");
         role.add("abilities", abilities);
         
         JsonObject featureLevels = new JsonObject();
@@ -577,6 +618,7 @@ public class SimpleDataGenerator {
         
         JsonArray abilities = new JsonArray();
         abilities.add("petsplus:voidbrand");
+        abilities.add("petsplus:void_storage");
         abilities.add("petsplus:phase_partner");
         abilities.add("petsplus:perch_ping");
         abilities.add("petsplus:event_horizon");

--- a/src/main/java/woflo/petsplus/effects/MagnetizeDropsAndXpEffect.java
+++ b/src/main/java/woflo/petsplus/effects/MagnetizeDropsAndXpEffect.java
@@ -4,22 +4,30 @@ import com.google.gson.JsonObject;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.entity.ExperienceOrbEntity;
 import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.collection.DefaultedList;
 import woflo.petsplus.api.Effect;
 import woflo.petsplus.api.EffectContext;
 import woflo.petsplus.api.registry.PetRoleType;
 import woflo.petsplus.config.PetsPlusConfig;
+import woflo.petsplus.roles.scout.ScoutBackpack;
+import woflo.petsplus.state.PetComponent;
 
+import net.minecraft.server.network.ServerPlayerEntity;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
+
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Effect that magnetizes item drops and experience orbs toward the owner.
@@ -59,9 +67,9 @@ public class MagnetizeDropsAndXpEffect implements Effect {
         if (!(context.getWorld() instanceof ServerWorld serverWorld)) {
             return false;
         }
-        
+
         // Start magnetization effect for the specified duration
-        scheduleMagnetization(serverWorld, owner, radius, durationTicks);
+        scheduleMagnetization(serverWorld, owner, context.getPet(), radius, durationTicks);
         return true;
     }
     
@@ -70,21 +78,40 @@ public class MagnetizeDropsAndXpEffect implements Effect {
         return durationTicks;
     }
     
-    private void scheduleMagnetization(ServerWorld world, PlayerEntity owner, double radius, int duration) {
+    private void scheduleMagnetization(ServerWorld world, PlayerEntity owner, @Nullable MobEntity pet,
+                                       double radius, int duration) {
         Map<UUID, MagnetizationState> worldStates = ACTIVE_MAGNETIZATIONS.computeIfAbsent(world, w -> new HashMap<>());
         UUID ownerId = owner.getUuid();
         long expiryTick = world.getTime() + duration;
         Vec3d anchor = owner.getPos();
+        PetComponent component = pet != null ? PetComponent.get(pet) : null;
+        ScoutBackpack.RoutingMode routingMode = ScoutBackpack.RoutingMode.PLAYER;
+        boolean routeToBackpack = false;
+        UUID petUuid = null;
+        if (owner instanceof ServerPlayerEntity && pet != null && component != null && component.isOwnedBy(owner)) {
+            routingMode = ScoutBackpack.getRoutingMode(component);
+            routeToBackpack = routingMode == ScoutBackpack.RoutingMode.PET
+                && ScoutBackpack.canRouteLootToBackpack(component, pet);
+            if (routeToBackpack) {
+                petUuid = pet.getUuid();
+            }
+        }
+
+        final ScoutBackpack.RoutingMode finalMode = routingMode;
+        final boolean finalRouteToBackpack = routeToBackpack;
+        final UUID finalPetUuid = petUuid;
 
         worldStates.compute(ownerId, (uuid, existing) -> {
             if (existing == null) {
-                return new MagnetizationState(anchor, radius, expiryTick);
+                return new MagnetizationState(anchor, radius, expiryTick, finalPetUuid, finalRouteToBackpack, finalMode);
             }
-            existing.refresh(anchor, radius, expiryTick);
+            existing.refresh(anchor, radius, expiryTick, finalPetUuid, finalRouteToBackpack, finalMode);
             return existing;
         });
 
-        magnetizeNearbyItems(world, owner, anchor, radius);
+        if (owner instanceof ServerPlayerEntity serverOwner) {
+            magnetizeNearbyItems(world, serverOwner, worldStates.get(ownerId));
+        }
     }
 
     private static void tickWorld(ServerWorld world) {
@@ -106,7 +133,7 @@ public class MagnetizeDropsAndXpEffect implements Effect {
             }
 
             PlayerEntity owner = world.getPlayerByUuid(entry.getKey());
-            if (owner == null || !owner.isAlive()) {
+            if (!(owner instanceof ServerPlayerEntity serverOwner) || !owner.isAlive()) {
                 iterator.remove();
                 continue;
             }
@@ -116,7 +143,7 @@ public class MagnetizeDropsAndXpEffect implements Effect {
                 continue;
             }
 
-            magnetizeNearbyItems(world, owner, state.getAnchor(), state.getRadius());
+            magnetizeNearbyItems(world, serverOwner, state);
         }
 
         if (worldStates.isEmpty()) {
@@ -124,19 +151,26 @@ public class MagnetizeDropsAndXpEffect implements Effect {
         }
     }
 
-    private static void magnetizeNearbyItems(ServerWorld world, PlayerEntity owner, Vec3d center, double radius) {
+    private static void magnetizeNearbyItems(ServerWorld world, ServerPlayerEntity owner, MagnetizationState state) {
+        Vec3d center = state.getAnchor();
+        double radius = state.getRadius();
         Box searchBox = Box.of(center, radius * 2, radius * 2, radius * 2);
         double radiusSquared = radius * radius;
 
-        // Magnetize item entities
-        List<ItemEntity> items = world.getEntitiesByClass(
-            ItemEntity.class,
-            searchBox,
-            item -> item.squaredDistanceTo(center) <= radiusSquared && !item.cannotPickup()
-        );
+        if (state.getMode() != ScoutBackpack.RoutingMode.OFF) {
+            // Magnetize item entities
+            List<ItemEntity> items = world.getEntitiesByClass(
+                ItemEntity.class,
+                searchBox,
+                item -> item.squaredDistanceTo(center) <= radiusSquared && !item.cannotPickup()
+            );
 
-        for (ItemEntity item : items) {
-            magnetizeToPlayer(item, owner);
+            for (ItemEntity item : items) {
+                if (state.tryHandleItem(world, owner, item)) {
+                    continue;
+                }
+                magnetizeToPlayer(item, owner);
+            }
         }
 
         // Magnetize experience orbs
@@ -160,6 +194,16 @@ public class MagnetizeDropsAndXpEffect implements Effect {
         item.setVelocity(velocity);
     }
 
+    private static void magnetizeToEntity(ItemEntity item, MobEntity entity) {
+        Vec3d target = entity.getPos().add(0.0, entity.getStandingEyeHeight() * 0.3, 0.0);
+        Vec3d toEntity = target.subtract(item.getPos());
+        if (toEntity.lengthSquared() == 0) {
+            return;
+        }
+        Vec3d velocity = toEntity.normalize().multiply(0.1);
+        item.setVelocity(velocity);
+    }
+
     private static void magnetizeToPlayer(ExperienceOrbEntity orb, PlayerEntity player) {
         Vec3d toPlayer = player.getPos().subtract(orb.getPos());
         if (toPlayer.lengthSquared() == 0) {
@@ -173,11 +217,18 @@ public class MagnetizeDropsAndXpEffect implements Effect {
         private Vec3d anchor;
         private double radius;
         private long expirationTick;
+        private @Nullable UUID petUuid;
+        private boolean routeToBackpack;
+        private ScoutBackpack.RoutingMode mode;
 
-        private MagnetizationState(Vec3d anchor, double radius, long expirationTick) {
+        private MagnetizationState(Vec3d anchor, double radius, long expirationTick, @Nullable UUID petUuid,
+                                   boolean routeToBackpack, ScoutBackpack.RoutingMode mode) {
             this.anchor = anchor;
             this.radius = radius;
             this.expirationTick = expirationTick;
+            this.petUuid = petUuid;
+            this.routeToBackpack = routeToBackpack;
+            this.mode = mode;
         }
 
         private Vec3d getAnchor() {
@@ -192,10 +243,56 @@ public class MagnetizeDropsAndXpEffect implements Effect {
             return expirationTick;
         }
 
-        private void refresh(Vec3d newAnchor, double newRadius, long newExpiryTick) {
+        private void refresh(Vec3d newAnchor, double newRadius, long newExpiryTick, @Nullable UUID petUuid,
+                              boolean routeToBackpack, ScoutBackpack.RoutingMode mode) {
             this.anchor = newAnchor;
             this.radius = Math.max(this.radius, newRadius);
             this.expirationTick = Math.max(this.expirationTick, newExpiryTick);
+            this.petUuid = petUuid;
+            this.routeToBackpack = routeToBackpack;
+            this.mode = mode;
+        }
+
+        private ScoutBackpack.RoutingMode getMode() {
+            return mode;
+        }
+
+        private boolean tryHandleItem(ServerWorld world, ServerPlayerEntity owner, ItemEntity item) {
+            if (mode != ScoutBackpack.RoutingMode.PET || !routeToBackpack || petUuid == null) {
+                return false;
+            }
+            var entity = world.getEntity(petUuid);
+            if (!(entity instanceof MobEntity pet) || !pet.isAlive()) {
+                routeToBackpack = false;
+                petUuid = null;
+                return false;
+            }
+            PetComponent component = PetComponent.get(pet);
+            if (component == null || !component.isOwnedBy(owner) || !ScoutBackpack.canRouteLootToBackpack(component, pet)) {
+                return false;
+            }
+
+            int storageSlots = ScoutBackpack.computeStorageSlots(component, pet);
+            if (storageSlots <= 0) {
+                return false;
+            }
+
+            if (!ScoutBackpack.isWithinPickupRange(pet, item)) {
+                magnetizeToEntity(item, pet);
+                return true;
+            }
+
+            DefaultedList<ItemStack> previousBacking = component.getInventoryIfPresent(ScoutBackpack.INVENTORY_KEY);
+            if (previousBacking != null) {
+                ScoutBackpack.handleOverflow(previousBacking, storageSlots, owner, pet);
+            }
+
+            DefaultedList<ItemStack> backing = component.getInventory(ScoutBackpack.INVENTORY_KEY, storageSlots);
+            if (!ScoutBackpack.canFullyInsert(backing, item.getStack())) {
+                return false;
+            }
+
+            return ScoutBackpack.tryStoreItem(world, owner, pet, component, backing, item);
         }
     }
 }

--- a/src/main/java/woflo/petsplus/effects/OpenEnderChestEffect.java
+++ b/src/main/java/woflo/petsplus/effects/OpenEnderChestEffect.java
@@ -1,0 +1,55 @@
+package woflo.petsplus.effects;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.EnderChestInventory;
+import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.SimpleNamedScreenHandlerFactory;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import woflo.petsplus.api.Effect;
+import woflo.petsplus.api.EffectContext;
+
+/**
+ * Opens the owner's ender chest UI when triggered.
+ */
+public class OpenEnderChestEffect implements Effect {
+    private static final Identifier ID = Identifier.of("petsplus", "open_ender_chest");
+
+    @Override
+    public Identifier getId() {
+        return ID;
+    }
+
+    @Override
+    public boolean execute(EffectContext context) {
+        PlayerEntity owner = context.getOwner();
+        if (!(owner instanceof ServerPlayerEntity serverOwner)) {
+            return false;
+        }
+
+        if (!serverOwner.isAlive() || serverOwner.isRemoved() || serverOwner.isSpectator()) {
+            return false;
+        }
+
+        EnderChestInventory enderChest = serverOwner.getEnderChestInventory();
+        if (enderChest == null || !enderChest.canPlayerUse(serverOwner)) {
+            return false;
+        }
+
+        serverOwner.openHandledScreen(new SimpleNamedScreenHandlerFactory(
+            (syncId, playerInventory, player) -> GenericContainerScreenHandler.createGeneric9x3(syncId, playerInventory, enderChest),
+            Text.translatable("container.enderchest")
+        ));
+
+        serverOwner.incrementStat(Stats.OPEN_ENDERCHEST);
+
+        return true;
+    }
+
+    @Override
+    public int getDurationTicks() {
+        return 0;
+    }
+}

--- a/src/main/java/woflo/petsplus/effects/OpenPetBackpackEffect.java
+++ b/src/main/java/woflo/petsplus/effects/OpenPetBackpackEffect.java
@@ -1,0 +1,93 @@
+package woflo.petsplus.effects;
+
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.SimpleNamedScreenHandlerFactory;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.MathHelper;
+import woflo.petsplus.api.Effect;
+import woflo.petsplus.api.EffectContext;
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.roles.scout.ScoutBackpack;
+
+/**
+ * Provides a persistent backpack inventory tied to the pet.
+ */
+public class OpenPetBackpackEffect implements Effect {
+    private static final Identifier ID = Identifier.of("petsplus", "open_pet_backpack");
+
+    @Override
+    public Identifier getId() {
+        return ID;
+    }
+
+    @Override
+    public boolean execute(EffectContext context) {
+        PlayerEntity owner = context.getOwner();
+        MobEntity pet = context.getPet();
+        if (!(owner instanceof ServerPlayerEntity serverOwner) || pet == null) {
+            return false;
+        }
+
+        if (!serverOwner.isAlive() || serverOwner.isRemoved() || serverOwner.isSpectator() || serverOwner.isSleeping()) {
+            return false;
+        }
+
+        if (!pet.isAlive() || pet.isRemoved()) {
+            return false;
+        }
+
+        PetComponent component = PetComponent.getOrCreate(pet);
+        if (component == null) {
+            return false;
+        }
+
+        int storageSlots = ScoutBackpack.computeStorageSlots(component, pet);
+        if (storageSlots <= 0) {
+            return false;
+        }
+
+        DefaultedList<ItemStack> previousBacking = component.getInventoryIfPresent(ScoutBackpack.INVENTORY_KEY);
+        if (previousBacking != null) {
+            ScoutBackpack.handleOverflow(previousBacking, storageSlots, serverOwner, pet);
+        }
+
+        DefaultedList<ItemStack> backing = component.getInventory(ScoutBackpack.INVENTORY_KEY, storageSlots);
+        component.setInventory(ScoutBackpack.INVENTORY_KEY, backing);
+
+        ScoutBackpack.MenuInventory inventory = new ScoutBackpack.MenuInventory(backing, component, pet);
+        int rows = inventory.getRows();
+
+        Text title = Text.translatable("container.petsplus.scout_backpack", pet.getDisplayName());
+        ScreenHandlerType<GenericContainerScreenHandler> handlerType = typeForRows(rows);
+
+        serverOwner.openHandledScreen(new SimpleNamedScreenHandlerFactory(
+            (syncId, playerInventory, player) -> new ScoutBackpack.ScoutBackpackScreenHandler(handlerType, syncId, playerInventory, inventory, pet.getUuid()),
+            title
+        ));
+
+        return true;
+    }
+
+    private static ScreenHandlerType<GenericContainerScreenHandler> typeForRows(int rows) {
+        return switch (MathHelper.clamp(rows, 1, 6)) {
+            case 1 -> ScreenHandlerType.GENERIC_9X1;
+            case 2 -> ScreenHandlerType.GENERIC_9X2;
+            case 3 -> ScreenHandlerType.GENERIC_9X3;
+            case 4 -> ScreenHandlerType.GENERIC_9X4;
+            case 5 -> ScreenHandlerType.GENERIC_9X5;
+            default -> ScreenHandlerType.GENERIC_9X6;
+        };
+    }
+
+    @Override
+    public int getDurationTicks() {
+        return 0;
+    }
+}

--- a/src/main/java/woflo/petsplus/roles/scout/ScoutBackpack.java
+++ b/src/main/java/woflo/petsplus/roles/scout/ScoutBackpack.java
@@ -1,0 +1,492 @@
+package woflo.petsplus.roles.scout;
+
+import net.minecraft.component.DataComponentTypes;
+import net.minecraft.component.type.LoreComponent;
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.inventory.Inventories;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.stat.Stats;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.collection.DefaultedList;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
+import woflo.petsplus.state.PetComponent;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Helper utilities for Scout backpack presentation and routing behaviour.
+ */
+public final class ScoutBackpack {
+    public static final String INVENTORY_KEY = "scout_backpack";
+    private static final String ROUTING_KEY = "scout_backpack_route_to_pet";
+    private static final int MAX_ROWS = 6;
+    private static final double PICKUP_RADIUS_SQ = 1.6 * 1.6;
+
+    private static final ItemStack LOCKED_SLOT_STACK;
+
+    static {
+        ItemStack locked = new ItemStack(Items.GRAY_STAINED_GLASS_PANE);
+        locked.set(DataComponentTypes.CUSTOM_NAME,
+            Text.translatable("container.petsplus.scout_backpack.locked").formatted(Formatting.DARK_GRAY));
+        LOCKED_SLOT_STACK = locked.copy();
+    }
+
+    private ScoutBackpack() {
+    }
+
+    public static int computeStorageSlots(PetComponent component, MobEntity pet) {
+        int baseRows = sizeRows(pet);
+        int bonusRows = levelBonusRows(component.getLevel());
+        int rows = MathHelper.clamp(baseRows + bonusRows, 1, MAX_ROWS);
+        int slots = rows * 9;
+        if (slots >= MAX_ROWS * 9) {
+            slots = (MAX_ROWS - 1) * 9;
+        }
+        return slots;
+    }
+
+    private static int sizeRows(MobEntity pet) {
+        float width = pet.getWidth();
+        float height = pet.getHeight();
+        float longest = Math.max(width, height);
+
+        if (longest < 0.6f) {
+            return 1;
+        }
+        if (longest < 1.2f) {
+            return 2;
+        }
+        return 3;
+    }
+
+    private static int levelBonusRows(int level) {
+        if (level >= 30) {
+            return 3;
+        }
+        if (level >= 20) {
+            return 2;
+        }
+        if (level >= 10) {
+            return 1;
+        }
+        return 0;
+    }
+
+    public enum RoutingMode {
+        PLAYER,
+        PET,
+        OFF;
+
+        public RoutingMode next() {
+            return switch (this) {
+                case PLAYER -> PET;
+                case PET -> OFF;
+                case OFF -> PLAYER;
+            };
+        }
+    }
+
+    public static RoutingMode getRoutingMode(PetComponent component) {
+        String stored = component.getStateData(ROUTING_KEY, String.class);
+        if (stored != null) {
+            try {
+                return RoutingMode.valueOf(stored.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ignored) {
+                // fall through to legacy handling/default
+            }
+        }
+
+        Boolean legacy = component.getStateData(ROUTING_KEY, Boolean.class);
+        if (legacy != null) {
+            RoutingMode mode = legacy ? RoutingMode.PET : RoutingMode.PLAYER;
+            setRoutingMode(component, mode);
+            return mode;
+        }
+
+        return RoutingMode.PLAYER;
+    }
+
+    public static boolean isRoutingToPet(PetComponent component) {
+        return getRoutingMode(component) == RoutingMode.PET;
+    }
+
+    public static void setRoutingMode(PetComponent component, RoutingMode mode) {
+        component.setStateData(ROUTING_KEY, mode.name());
+    }
+
+    public static boolean canRouteLootToBackpack(PetComponent component, MobEntity pet) {
+        if (component == null || pet == null || !pet.isAlive()) {
+            return false;
+        }
+        if (getRoutingMode(component) != RoutingMode.PET) {
+            return false;
+        }
+        if (pet.getTarget() != null) {
+            return false;
+        }
+        PetComponent.Mood mood = component.getCurrentMood();
+        if (mood == null) {
+            return true;
+        }
+        return switch (mood) {
+            case CALM, BONDED, HAPPY, PLAYFUL, CURIOUS -> true;
+            default -> false;
+        };
+    }
+
+    public static int computeMenuSlots(int storageSlots) {
+        int desired = Math.min(storageSlots + 1, MAX_ROWS * 9);
+        int rows = MathHelper.clamp(MathHelper.ceilDiv(desired, 9), 1, MAX_ROWS);
+        return rows * 9;
+    }
+
+    public static ItemStack createToggleStack(RoutingMode mode, MobEntity pet) {
+        ItemStack stack = switch (mode) {
+            case PET -> new ItemStack(Items.MAGENTA_STAINED_GLASS_PANE);
+            case PLAYER -> new ItemStack(Items.LIGHT_BLUE_STAINED_GLASS_PANE);
+            case OFF -> new ItemStack(Items.RED_STAINED_GLASS_PANE);
+        };
+        Text name = switch (mode) {
+            case PET -> Text.translatable("container.petsplus.scout_backpack.toggle.pet", pet.getDisplayName())
+                .formatted(Formatting.LIGHT_PURPLE);
+            case PLAYER -> Text.translatable("container.petsplus.scout_backpack.toggle.player")
+                .formatted(Formatting.AQUA);
+            case OFF -> Text.translatable("container.petsplus.scout_backpack.toggle.off")
+                .formatted(Formatting.RED);
+        };
+        stack.set(DataComponentTypes.CUSTOM_NAME, name);
+        stack.set(DataComponentTypes.LORE, new LoreComponent(List.of(
+            Text.translatable("container.petsplus.scout_backpack.toggle.hint")
+                .formatted(Formatting.GRAY)
+        )));
+        return stack;
+    }
+
+    public static ItemStack lockedStack() {
+        return LOCKED_SLOT_STACK.copy();
+    }
+
+    public static boolean canFullyInsert(DefaultedList<ItemStack> backing, ItemStack stack) {
+        if (stack.isEmpty()) {
+            return true;
+        }
+        int remaining = stack.getCount();
+        for (int i = 0; i < backing.size() && remaining > 0; i++) {
+            ItemStack existing = backing.get(i);
+            if (existing.isEmpty()) {
+                remaining -= Math.min(remaining, stack.getMaxCount());
+            } else if (ItemStack.areItemsAndComponentsEqual(existing, stack)) {
+                int space = Math.min(existing.getMaxCount(), backing.get(i).getMaxCount()) - existing.getCount();
+                if (space > 0) {
+                    remaining -= Math.min(space, remaining);
+                }
+            }
+        }
+        return remaining <= 0;
+    }
+
+    public static void insertIntoBackpack(DefaultedList<ItemStack> backing, ItemStack stack) {
+        if (stack.isEmpty()) {
+            return;
+        }
+        for (int i = 0; i < backing.size(); i++) {
+            ItemStack existing = backing.get(i);
+            if (!existing.isEmpty() && ItemStack.areItemsAndComponentsEqual(existing, stack)) {
+                int space = Math.min(existing.getMaxCount(), backing.get(i).getMaxCount()) - existing.getCount();
+                if (space <= 0) {
+                    continue;
+                }
+                int transfer = Math.min(space, stack.getCount());
+                if (transfer <= 0) {
+                    continue;
+                }
+                existing.increment(transfer);
+                stack.decrement(transfer);
+                if (stack.isEmpty()) {
+                    return;
+                }
+            }
+        }
+
+        if (!stack.isEmpty()) {
+            for (int i = 0; i < backing.size(); i++) {
+                ItemStack existing = backing.get(i);
+                if (existing.isEmpty()) {
+                    backing.set(i, stack.copy());
+                    stack.setCount(0);
+                    return;
+                }
+            }
+        }
+    }
+
+    public static void handleOverflow(DefaultedList<ItemStack> previousBacking, int slotCount,
+                                      @Nullable ServerPlayerEntity owner, MobEntity pet) {
+        if (previousBacking == null || slotCount >= previousBacking.size()) {
+            return;
+        }
+
+        for (int i = slotCount; i < previousBacking.size(); i++) {
+            ItemStack stack = previousBacking.get(i);
+            if (stack == null || stack.isEmpty()) {
+                continue;
+            }
+
+            ItemStack overflow = stack.copy();
+            previousBacking.set(i, ItemStack.EMPTY);
+
+            if (owner != null) {
+                boolean fullyInserted = owner.getInventory().insertStack(overflow);
+                if (!fullyInserted && !overflow.isEmpty()) {
+                    owner.dropItem(overflow, false);
+                }
+            } else if (pet.getWorld() instanceof ServerWorld serverWorld && !overflow.isEmpty()) {
+                ItemEntity entity = new ItemEntity(serverWorld, pet.getX(), pet.getBodyY(0.5), pet.getZ(), overflow);
+                entity.setToDefaultPickupDelay();
+                serverWorld.spawnEntity(entity);
+            }
+        }
+    }
+
+    public static boolean tryStoreItem(ServerWorld world, ServerPlayerEntity owner, MobEntity pet,
+                                       PetComponent component, DefaultedList<ItemStack> backing,
+                                       ItemEntity item) {
+        if (item.isRemoved()) {
+            return false;
+        }
+        ItemStack stack = item.getStack();
+        if (!canFullyInsert(backing, stack)) {
+            return false;
+        }
+        ItemStack copy = stack.copy();
+        insertIntoBackpack(backing, copy);
+        component.setInventory(INVENTORY_KEY, backing);
+
+        Vec3d pos = pet.getPos();
+        world.playSound(null, pos.x, pos.y, pos.z, SoundEvents.ENTITY_ITEM_PICKUP,
+            SoundCategory.PLAYERS, 0.25f, 1.2f + world.random.nextFloat() * 0.1f);
+        if (owner != null) {
+            owner.sendPickup(item, stack.getCount());
+            owner.increaseStat(Stats.PICKED_UP.getOrCreateStat(stack.getItem()), stack.getCount());
+        }
+        item.discard();
+        refreshOpenBackpack(owner, pet.getUuid());
+        return true;
+    }
+
+    public static void refreshOpenBackpack(@Nullable ServerPlayerEntity owner, UUID petUuid) {
+        if (owner == null) {
+            return;
+        }
+        if (owner.currentScreenHandler instanceof ScoutBackpackScreenHandler handler && handler.isForPet(petUuid)) {
+            handler.refreshFromBacking();
+        }
+    }
+
+    public static boolean isWithinPickupRange(MobEntity pet, ItemEntity item) {
+        return item.squaredDistanceTo(pet) <= PICKUP_RADIUS_SQ;
+    }
+
+    public static final class MenuInventory implements Inventory {
+        private final DefaultedList<ItemStack> backing;
+        private final PetComponent component;
+        private final MobEntity pet;
+        private final int menuSlots;
+        private final int toggleSlot;
+        private final int[] slotToStorageIndex;
+        private ItemStack toggleStack;
+        private boolean suppressDirty;
+
+        public MenuInventory(DefaultedList<ItemStack> backing, PetComponent component, MobEntity pet) {
+            this.backing = backing;
+            this.component = component;
+            this.pet = pet;
+            int storageSlots = backing.size();
+            this.menuSlots = computeMenuSlots(storageSlots);
+            this.toggleSlot = Math.min(menuSlots - 1, MAX_ROWS * 9 - 1);
+            this.slotToStorageIndex = new int[menuSlots];
+            Arrays.fill(this.slotToStorageIndex, -2);
+            int storageIndex = 0;
+            for (int slot = 0; slot < menuSlots && storageIndex < storageSlots; slot++) {
+                if (slot == toggleSlot) {
+                    continue;
+                }
+                slotToStorageIndex[slot] = storageIndex++;
+            }
+            syncFromBacking();
+        }
+
+        public int getRows() {
+            return MathHelper.clamp(menuSlots / 9, 1, MAX_ROWS);
+        }
+
+        public boolean isToggleSlot(int slot) {
+            return slot == toggleSlot;
+        }
+
+        public void syncFromBacking() {
+            this.toggleStack = createToggleStack(getRoutingMode(component), pet);
+        }
+
+        public void refreshToggle() {
+            this.toggleStack = createToggleStack(getRoutingMode(component), pet);
+        }
+
+        @Override
+        public int size() {
+            return menuSlots;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            for (ItemStack stack : backing) {
+                if (!stack.isEmpty()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public ItemStack getStack(int slot) {
+            if (slot == toggleSlot) {
+                return toggleStack.copy();
+            }
+            int storageIndex = slotToStorageIndex[slot];
+            if (storageIndex >= 0 && storageIndex < backing.size()) {
+                return backing.get(storageIndex);
+            }
+            return lockedStack();
+        }
+
+        @Override
+        public ItemStack removeStack(int slot, int amount) {
+            int storageIndex = slotToStorageIndex[slot];
+            if (storageIndex >= 0) {
+                ItemStack result = Inventories.splitStack(backing, storageIndex, amount);
+                if (!result.isEmpty()) {
+                    markDirty();
+                }
+                return result;
+            }
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public ItemStack removeStack(int slot) {
+            int storageIndex = slotToStorageIndex[slot];
+            if (storageIndex >= 0) {
+                ItemStack result = Inventories.removeStack(backing, storageIndex);
+                if (!result.isEmpty()) {
+                    markDirty();
+                }
+                return result;
+            }
+            return ItemStack.EMPTY;
+        }
+
+        @Override
+        public void setStack(int slot, ItemStack stack) {
+            int storageIndex = slotToStorageIndex[slot];
+            if (storageIndex >= 0) {
+                backing.set(storageIndex, stack);
+                markDirty();
+            }
+        }
+
+        @Override
+        public void markDirty() {
+            if (suppressDirty) {
+                return;
+            }
+            suppressDirty = true;
+            component.setInventory(INVENTORY_KEY, backing);
+            suppressDirty = false;
+        }
+
+        @Override
+        public boolean canPlayerUse(PlayerEntity player) {
+            return component.isOwnedBy(player);
+        }
+
+        @Override
+        public void clear() {
+            for (int i = 0; i < backing.size(); i++) {
+                backing.set(i, ItemStack.EMPTY);
+            }
+            markDirty();
+        }
+
+        public RoutingMode toggleRouting(ServerPlayerEntity player) {
+            RoutingMode next = getRoutingMode(component).next();
+            setRoutingMode(component, next);
+            refreshToggle();
+            Text feedback = switch (next) {
+                case PET -> Text.translatable("message.petsplus.scout_backpack.route.pet", pet.getDisplayName());
+                case PLAYER -> Text.translatable("message.petsplus.scout_backpack.route.player");
+                case OFF -> Text.translatable("message.petsplus.scout_backpack.route.off");
+            };
+            player.sendMessage(feedback, true);
+            return next;
+        }
+    }
+
+    public static class ScoutBackpackScreenHandler extends GenericContainerScreenHandler {
+        private final MenuInventory inventory;
+        private final UUID petUuid;
+
+        public ScoutBackpackScreenHandler(ScreenHandlerType<GenericContainerScreenHandler> type, int syncId,
+                                          net.minecraft.entity.player.PlayerInventory playerInventory,
+                                          MenuInventory inventory, UUID petUuid) {
+            super(type, syncId, playerInventory, inventory, inventory.getRows());
+            this.inventory = inventory;
+            this.petUuid = petUuid;
+        }
+
+        @Override
+        public void onSlotClick(int slot, int button, net.minecraft.screen.slot.SlotActionType actionType,
+                                PlayerEntity player) {
+            if (slot >= 0 && slot < inventory.size() && inventory.isToggleSlot(slot) && player instanceof ServerPlayerEntity serverPlayer) {
+                inventory.toggleRouting(serverPlayer);
+                inventory.refreshToggle();
+                sendContentUpdates();
+                return;
+            }
+            super.onSlotClick(slot, button, actionType, player);
+        }
+
+        @Override
+        public boolean canUse(PlayerEntity player) {
+            return inventory.canPlayerUse(player);
+        }
+
+        public boolean isForPet(UUID petUuid) {
+            return this.petUuid.equals(petUuid);
+        }
+
+        public void refreshFromBacking() {
+            inventory.syncFromBacking();
+            for (Slot slot : slots) {
+                slot.markDirty();
+            }
+            sendContentUpdates();
+        }
+    }
+}

--- a/src/main/resources/assets/petsplus/lang/en_us.json
+++ b/src/main/resources/assets/petsplus/lang/en_us.json
@@ -1,4 +1,13 @@
 {
+  "container.petsplus.scout_backpack": "%s's Scout Backpack",
+  "container.petsplus.scout_backpack.toggle.player": "Loot routing: Player inventory",
+  "container.petsplus.scout_backpack.toggle.pet": "Loot routing: %s's backpack",
+  "container.petsplus.scout_backpack.toggle.off": "Loot magnet disabled",
+  "container.petsplus.scout_backpack.toggle.hint": "Click to cycle routing modes",
+  "container.petsplus.scout_backpack.locked": "Reserved slot",
+  "message.petsplus.scout_backpack.route.pet": "Loot will now fill %s's backpack.",
+  "message.petsplus.scout_backpack.route.player": "Loot will now go to your inventory.",
+  "message.petsplus.scout_backpack.route.off": "Loot magnet disabled.",
   "petsplus.guardian.bulwark": "%s holds the line. (+Proj DR)",
   "petsplus.guardian.projectile_dr": "Protected by guardian shield",
   "petsplus.striker.finisher_mark": "%s marked a finisher.",

--- a/src/main/resources/data/petsplus/abilities/scout_backpack.json
+++ b/src/main/resources/data/petsplus/abilities/scout_backpack.json
@@ -1,0 +1,13 @@
+{
+  "id": "petsplus:scout_backpack",
+  "required_level": 5,
+  "trigger": {
+    "event": "owner_signal_proximity_channel",
+    "cooldown_ticks": 40
+  },
+  "effects": [
+    {
+      "type": "open_pet_backpack"
+    }
+  ]
+}

--- a/src/main/resources/data/petsplus/abilities/void_storage.json
+++ b/src/main/resources/data/petsplus/abilities/void_storage.json
@@ -1,0 +1,13 @@
+{
+  "id": "petsplus:void_storage",
+  "required_level": 7,
+  "trigger": {
+    "event": "owner_signal_proximity_channel",
+    "cooldown_ticks": 120
+  },
+  "effects": [
+    {
+      "type": "open_ender_chest"
+    }
+  ]
+}

--- a/src/main/resources/data/petsplus/roles/eclipsed.json
+++ b/src/main/resources/data/petsplus/roles/eclipsed.json
@@ -11,6 +11,7 @@
   },
   "default_abilities": [
     "petsplus:voidbrand",
+    "petsplus:void_storage",
     "petsplus:phase_partner",
     "petsplus:perch_ping"
   ],

--- a/src/main/resources/data/petsplus/roles/scout.json
+++ b/src/main/resources/data/petsplus/roles/scout.json
@@ -14,7 +14,8 @@
     "speed_max_bonus": 0.6
   },
   "default_abilities": [
-    "petsplus:loot_wisp"
+    "petsplus:loot_wisp",
+    "petsplus:scout_backpack"
   ],
   "tribute_defaults": {
     "10": "minecraft:gold_ingot",


### PR DESCRIPTION
## Summary
- switch the scout backpack routing toggle to colored stained glass panes for each state
- keep the existing lore and naming so the reserved slot clearly communicates its function while matching the requested visuals

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68d58935088c832f9e1f22c0dd96a2b4