### PR TITLE
Add admin pet snapshot import/export commands

### DIFF
--- a/src/main/java/woflo/petsplus/commands/PetsCommand.java
+++ b/src/main/java/woflo/petsplus/commands/PetsCommand.java
@@ -10,11 +10,17 @@ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.command.CommandSource;
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.ClickEvent.CopyToClipboard;
+import net.minecraft.text.HoverEvent;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
 import net.minecraft.text.Text;
+import net.minecraft.text.TextColor;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import org.jetbrains.annotations.Nullable;
@@ -25,10 +31,13 @@ import woflo.petsplus.commands.suggestions.PetsSuggestionProviders;
 import woflo.petsplus.config.PetsPlusConfig;
 import woflo.petsplus.events.EmotionContextCues;
 import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetSnapshot;
 import woflo.petsplus.ui.ChatLinks;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +45,8 @@ import java.util.stream.Collectors;
  * Replaces the old TestCommands with proper structure and suggestions.
  */
 public class PetsCommand {
+
+    private static final int SNAPSHOT_CHAT_CHUNK = 256;
     
     // Custom suggestion providers following Fabric documentation
     public static final SuggestionProvider<ServerCommandSource> ROLE_SUGGESTIONS = (context, builder) -> {
@@ -114,7 +125,14 @@ public class PetsCommand {
                         .executes(context -> toggleDebug(context, false))))
                 .then(CommandManager.literal("setlevel")
                     .then(CommandManager.argument("level", StringArgumentType.string())
-                        .executes(PetsCommand::adminSetPetLevel))))
+                        .executes(PetsCommand::adminSetPetLevel)))
+                .then(CommandManager.literal("export")
+                    .executes(PetsCommand::adminExportAnyPet)
+                    .then(CommandManager.argument("pet_name", StringArgumentType.greedyString())
+                        .executes(PetsCommand::adminExportNamedPet)))
+                .then(CommandManager.literal("import")
+                    .then(CommandManager.argument("snapshot", StringArgumentType.greedyString())
+                        .executes(PetsCommand::adminImportPet))))
 
             .then(CommandManager.literal("journal")
                 .executes(PetsCommand::showCueJournal))
@@ -443,6 +461,98 @@ public class PetsCommand {
         player.sendMessage(Text.literal("Pet level set to " + level + "!").formatted(Formatting.GREEN), false);
         return 1;
     }
+
+    private static int adminExportAnyPet(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        ServerPlayerEntity player = context.getSource().getPlayerOrThrow();
+        return performAdminExport(player, null);
+    }
+
+    private static int adminExportNamedPet(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        ServerPlayerEntity player = context.getSource().getPlayerOrThrow();
+        String query = StringArgumentType.getString(context, "pet_name");
+        return performAdminExport(player, query);
+    }
+
+    private static int adminImportPet(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        ServerPlayerEntity player = context.getSource().getPlayerOrThrow();
+        String raw = StringArgumentType.getString(context, "snapshot");
+        String normalized = raw.replaceAll("\\s+", "");
+
+        if (normalized.isEmpty()) {
+            player.sendMessage(Text.literal("Snapshot payload was empty.").formatted(Formatting.RED), false);
+            return 0;
+        }
+
+        try {
+            MobEntity imported = PetSnapshot.importFromString(normalized, player);
+            player.sendMessage(Text.literal("✅ Imported " + getPetDisplayName(imported) + " in front of you.")
+                .formatted(Formatting.GREEN), false);
+            return 1;
+        } catch (PetSnapshot.SnapshotException e) {
+            player.sendMessage(Text.literal("Failed to import pet: " + e.getMessage()).formatted(Formatting.RED), false);
+            return 0;
+        }
+    }
+
+    private static int performAdminExport(ServerPlayerEntity player, @Nullable String query) {
+        List<MobEntity> candidates = findNearbyTrackedPets(player);
+        if (candidates.isEmpty()) {
+            player.sendMessage(Text.literal("No PetsPlus companions found nearby to export.")
+                .formatted(Formatting.RED), false);
+            return 0;
+        }
+
+        MobEntity target = selectAdminPet(candidates, player, query);
+        if (target == null) {
+            player.sendMessage(Text.literal("Couldn't find a pet matching '" + query + "'. Nearby pets:")
+                .formatted(Formatting.RED), false);
+            for (MobEntity candidate : candidates) {
+                player.sendMessage(Text.literal("  • " + describePet(candidate))
+                    .formatted(Formatting.GRAY), false);
+            }
+            return 0;
+        }
+
+        if ((query == null || query.isBlank()) && candidates.size() > 1) {
+            player.sendMessage(Text.literal("Multiple pets detected; exporting nearest " + getPetDisplayName(target)
+                    + ". Use /petsplus admin export <name> to specify a different one.")
+                .formatted(Formatting.YELLOW), false);
+        }
+
+        try {
+            String blob = PetSnapshot.exportToString(target);
+            String display = getPetDisplayName(target);
+            player.sendMessage(Text.literal("✅ Exported snapshot for " + display + ".")
+                .formatted(Formatting.GREEN), false);
+            ChatLinks.sendCopy(player, new ChatLinks.Copy("[Copy Pet Snapshot]", blob,
+                "Click to copy the pet snapshot to your clipboard", "#55FFAA", true));
+            sendSnapshotChunks(player, blob);
+            return 1;
+        } catch (PetSnapshot.SnapshotException e) {
+            player.sendMessage(Text.literal("Failed to export pet: " + e.getMessage()).formatted(Formatting.RED), false);
+            return 0;
+        }
+    }
+
+    private static void sendSnapshotChunks(ServerPlayerEntity player, String blob) {
+        int total = Math.max(1, (blob.length() + SNAPSHOT_CHAT_CHUNK - 1) / SNAPSHOT_CHAT_CHUNK);
+        player.sendMessage(Text.literal("Snapshot payload (" + total + " chunk" + (total == 1 ? "" : "s") + "):")
+            .formatted(Formatting.GRAY), false);
+
+        for (int index = 0; index < total; index++) {
+            int start = index * SNAPSHOT_CHAT_CHUNK;
+            int end = Math.min(blob.length(), start + SNAPSHOT_CHAT_CHUNK);
+            String chunk = blob.substring(start, end);
+            Text prefix = Text.literal(String.format(Locale.ROOT, "[%d/%d] ", index + 1, total))
+                .formatted(Formatting.DARK_GRAY);
+            MutableText content = Text.literal(chunk).setStyle(Style.EMPTY
+                .withColor(TextColor.fromRgb(Formatting.AQUA.getColorValue()))
+                .withUnderline(true)
+                .withClickEvent(new CopyToClipboard(chunk))
+                .withHoverEvent(new HoverEvent.ShowText(Text.literal("Click to copy this chunk"))));
+            player.sendMessage(prefix.copy().append(content), false);
+        }
+    }
     
     /**
      * Find the nearest pet owned by the player within 10 blocks.
@@ -529,6 +639,65 @@ public class PetsCommand {
                 return petComp != null && petComp.isOwnedBy(player);
             }
         );
+    }
+
+    private static List<MobEntity> findNearbyTrackedPets(ServerPlayerEntity player) {
+        return player.getWorld().getEntitiesByClass(
+            MobEntity.class,
+            player.getBoundingBox().expand(12),
+            entity -> PetComponent.get(entity) != null
+        );
+    }
+
+    private static MobEntity selectAdminPet(List<MobEntity> candidates, ServerPlayerEntity player, @Nullable String query) {
+        if (candidates.isEmpty()) {
+            return null;
+        }
+
+        if (query == null || query.isBlank()) {
+            return candidates.stream()
+                .min(Comparator.comparingDouble(entity -> entity.squaredDistanceTo(player)))
+                .orElse(null);
+        }
+
+        String normalized = query.trim().toLowerCase(Locale.ROOT);
+
+        for (MobEntity candidate : candidates) {
+            if (candidate.hasCustomName() && candidate.getCustomName().getString().equalsIgnoreCase(query)) {
+                return candidate;
+            }
+        }
+
+        for (MobEntity candidate : candidates) {
+            String display = getPetDisplayName(candidate).toLowerCase(Locale.ROOT);
+            if (display.contains(normalized)) {
+                return candidate;
+            }
+
+            Identifier typeId = Registries.ENTITY_TYPE.getId(candidate.getType());
+            if (typeId != null && typeId.toString().toLowerCase(Locale.ROOT).contains(normalized)) {
+                return candidate;
+            }
+
+            if (candidate.getUuidAsString().toLowerCase(Locale.ROOT).startsWith(normalized)) {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static String describePet(MobEntity pet) {
+        String display = getPetDisplayName(pet);
+        Identifier typeId = Registries.ENTITY_TYPE.getId(pet.getType());
+        String type = typeId != null ? typeId.toString() : pet.getType().getName().getString();
+        String uuid = pet.getUuidAsString();
+        String shortUuid = uuid.length() > 8 ? uuid.substring(0, 8) : uuid;
+        return display + " [" + type + " • " + shortUuid + "]";
+    }
+
+    private static String getPetDisplayName(MobEntity pet) {
+        return pet.hasCustomName() ? pet.getCustomName().getString() : pet.getType().getName().getString();
     }
 
     private static Text resolveRoleLabel(Identifier roleId, @Nullable PetRoleType roleType) {

--- a/src/main/java/woflo/petsplus/state/PetSnapshot.java
+++ b/src/main/java/woflo/petsplus/state/PetSnapshot.java
@@ -1,0 +1,224 @@
+package woflo.petsplus.state;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.NbtSizeTracker;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.Util;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.storage.NbtReadView;
+import net.minecraft.storage.NbtWriteView;
+import net.minecraft.storage.ReadView;
+import net.minecraft.util.ErrorReporter;
+import woflo.petsplus.api.entity.PetsplusTameable;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility that snapshots and restores pet state, including vanilla entity NBT and
+ * the PetsPlus {@link PetComponent} payload, to enable import/export through chat commands.
+ */
+public final class PetSnapshot {
+
+    private static final String KEY_VERSION = "version";
+    private static final String KEY_ENTITY_TYPE = "entity_type";
+    private static final String KEY_VANILLA = "vanilla";
+    private static final String KEY_COMPONENT = "component";
+    private static final int CURRENT_VERSION = 1;
+    private static final Set<String> VANILLA_EXCLUDED_KEYS = Util.make(new HashSet<>(), keys -> {
+        keys.add("Pos");
+        keys.add("Motion");
+        keys.add("Rotation");
+        keys.add("UUID");
+        keys.add("UUIDMost");
+        keys.add("UUIDLeast");
+        keys.add("Dimension");
+        keys.add("WorldUUIDMost");
+        keys.add("WorldUUIDLeast");
+        keys.add("WorldUUID");
+        keys.add("PortalCooldown");
+        keys.add("LoveCause");
+        keys.add("HurtBy");
+        keys.add("AngryAt");
+        keys.add("Leash");
+        keys.add("Owner");
+        keys.add("OwnerUUID");
+    });
+
+    private PetSnapshot() {
+    }
+
+    /**
+     * Capture all mod-owned and vanilla state for the supplied pet and encode it as a Base64 payload.
+     */
+    public static String exportToString(MobEntity pet) throws SnapshotException {
+        Identifier typeId = Registries.ENTITY_TYPE.getId(pet.getType());
+        if (typeId == null) {
+            throw new SnapshotException("Unable to resolve entity type for export");
+        }
+
+        NbtCompound root = new NbtCompound();
+        root.putInt(KEY_VERSION, CURRENT_VERSION);
+        root.putString(KEY_ENTITY_TYPE, typeId.toString());
+
+        NbtCompound vanilla = captureVanillaState(pet);
+        root.put(KEY_VANILLA, vanilla);
+
+        PetComponent component = PetComponent.get(pet);
+        if (component == null) {
+            component = PetComponent.getOrCreate(pet);
+        }
+        NbtCompound componentPayload = new NbtCompound();
+        component.writeToNbt(componentPayload);
+        componentPayload.remove("petUuid");
+        root.put(KEY_COMPONENT, componentPayload);
+
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            NbtIo.writeCompressed(root, output);
+            return Base64.getEncoder().encodeToString(output.toByteArray());
+        } catch (IOException e) {
+            throw new SnapshotException("Failed to encode pet snapshot", e);
+        }
+    }
+
+    /**
+     * Recreate a pet from the supplied payload and place it in front of the player.
+     */
+    public static MobEntity importFromString(String payload, ServerPlayerEntity player) throws SnapshotException {
+        SnapshotData data = decode(payload);
+
+        ServerWorld world = player.getWorld();
+        EntityType<?> entityType = Registries.ENTITY_TYPE.get(data.entityTypeId());
+        if (entityType == null) {
+            throw new SnapshotException("Unknown entity type: " + data.entityTypeId());
+        }
+        Entity created = entityType.create(world, SpawnReason.COMMAND);
+        if (!(created instanceof MobEntity pet)) {
+            throw new SnapshotException("Snapshot entity type is not a mob: " + data.entityTypeId());
+        }
+
+        Vec3d spawnPos = positionInFrontOfPlayer(player, 1.5);
+        pet.refreshPositionAndAngles(spawnPos.x, spawnPos.y, spawnPos.z, player.getYaw(), player.getPitch());
+
+        NbtCompound vanillaData = data.vanillaNbt().copy();
+        RegistryWrapper.WrapperLookup registryLookup = world.getRegistryManager();
+        ReadView readView = NbtReadView.create(ErrorReporter.EMPTY, registryLookup, vanillaData);
+        pet.readData(readView);
+        pet.refreshPositionAndAngles(spawnPos.x, spawnPos.y, spawnPos.z, player.getYaw(), player.getPitch());
+
+        if (!world.spawnEntity(pet)) {
+            throw new SnapshotException("World rejected spawned pet instance");
+        }
+
+        PetComponent component = StateManager.forWorld(world).getPetComponent(pet);
+        component.readFromNbt(data.componentNbt().copy());
+        component.setOwner(player);
+        component.ensureCharacteristics();
+        component.refreshSpeciesDescriptor();
+
+        applyTameBridge(pet, player);
+
+        return pet;
+    }
+
+    private static void applyTameBridge(MobEntity pet, ServerPlayerEntity owner) {
+        if (pet instanceof PetsplusTameable tameable) {
+            tameable.petsplus$setOwner(owner);
+            tameable.petsplus$setTamed(true);
+        }
+    }
+
+    private static Vec3d positionInFrontOfPlayer(ServerPlayerEntity player, double distance) {
+        Vec3d look = player.getRotationVec(1.0F).normalize();
+        Vec3d base = player.getPos().add(look.multiply(distance));
+        return new Vec3d(base.x, player.getY(), base.z);
+    }
+
+    private static NbtCompound captureVanillaState(MobEntity pet) {
+        if (!(pet.getWorld() instanceof ServerWorld serverWorld)) {
+            return new NbtCompound();
+        }
+
+        RegistryWrapper.WrapperLookup registryLookup = serverWorld.getRegistryManager();
+        NbtWriteView writeView = NbtWriteView.create(ErrorReporter.EMPTY, registryLookup);
+        pet.saveSelfData(writeView);
+        NbtCompound vanilla = writeView.getNbt();
+        for (String key : VANILLA_EXCLUDED_KEYS) {
+            vanilla.remove(key);
+        }
+        return vanilla;
+    }
+
+    private static SnapshotData decode(String payload) throws SnapshotException {
+        byte[] bytes;
+        try {
+            bytes = Base64.getDecoder().decode(payload);
+        } catch (IllegalArgumentException e) {
+            throw new SnapshotException("Snapshot blob is not valid Base64", e);
+        }
+
+        NbtCompound root;
+        try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
+            root = NbtIo.readCompressed(input, NbtSizeTracker.ofUnlimitedBytes());
+        } catch (IOException e) {
+            throw new SnapshotException("Unable to decompress snapshot data", e);
+        }
+
+        int version = root.contains(KEY_VERSION)
+            ? root.getInt(KEY_VERSION).orElse(0)
+            : 0;
+        if (version > CURRENT_VERSION) {
+            throw new SnapshotException("Snapshot was created with a newer version (" + version + ")");
+        }
+
+        String typeString = root.getString(KEY_ENTITY_TYPE).orElse("");
+        if (typeString == null || typeString.isEmpty()) {
+            throw new SnapshotException("Snapshot is missing entity type information");
+        }
+
+        Identifier typeId = Identifier.tryParse(typeString);
+        if (typeId == null) {
+            throw new SnapshotException("Snapshot contains invalid entity type: " + typeString);
+        }
+
+        NbtCompound vanilla = root.getCompound(KEY_VANILLA)
+            .map(NbtCompound::copy)
+            .orElseGet(NbtCompound::new);
+        NbtCompound component = root.getCompound(KEY_COMPONENT)
+            .map(NbtCompound::copy)
+            .orElseGet(NbtCompound::new);
+
+        component.remove("petUuid");
+        component.getCompound("stateData").ifPresent(state -> state.remove("petsplus:owner_uuid"));
+
+        return new SnapshotData(typeId, vanilla, component);
+    }
+
+    public record SnapshotData(Identifier entityTypeId, NbtCompound vanillaNbt, NbtCompound componentNbt) {
+    }
+
+    public static class SnapshotException extends Exception {
+        public SnapshotException(String message) {
+            super(message);
+        }
+
+        public SnapshotException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}
+

--- a/src/main/java/woflo/petsplus/ui/ChatLinks.java
+++ b/src/main/java/woflo/petsplus/ui/ChatLinks.java
@@ -1,6 +1,10 @@
 package woflo.petsplus.ui;
 
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.ClickEvent.CopyToClipboard;
+import net.minecraft.text.HoverEvent;
+import net.minecraft.text.HoverEvent.ShowText;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
@@ -23,6 +27,11 @@ public class ChatLinks {
     public record RunCommand(String label, String command, String hover, String color, boolean bold) {}
 
     /**
+     * Container for a formatted text component that copies a payload to the clipboard when clicked.
+     */
+    public record Copy(String label, String payload, String hover, String color, boolean bold) {}
+
+    /**
      * Send a single formatted text component line to a player.
      */
     public static void sendSuggest(ServerPlayerEntity player, Suggest suggest) {
@@ -38,6 +47,27 @@ public class ChatLinks {
     public static void sendRunCommand(ServerPlayerEntity player, RunCommand command) {
         if (player == null || command == null) return;
         MutableText text = createFormattedText(command.label(), command.color(), command.bold());
+        player.sendMessage(text, false);
+    }
+
+    /**
+     * Send a formatted component that copies the supplied payload when clicked.
+     */
+    public static void sendCopy(ServerPlayerEntity player, Copy copy) {
+        if (player == null || copy == null) return;
+
+        MutableText text = createFormattedText(copy.label(), copy.color(), copy.bold());
+        Style style = text.getStyle();
+
+        if (copy.payload() != null && !copy.payload().isEmpty()) {
+            style = style.withClickEvent(new CopyToClipboard(copy.payload()));
+        }
+
+        if (copy.hover() != null && !copy.hover().isEmpty()) {
+            style = style.withHoverEvent(new ShowText(Text.literal(copy.hover())));
+        }
+
+        text.setStyle(style);
         player.sendMessage(text, false);
     }
 


### PR DESCRIPTION
## Summary
- add a PetSnapshot helper that captures vanilla entity data alongside the PetsPlus component payload so pets can be serialized to text blobs
- extend `/petsplus admin` with `export` and `import` subcommands that share copy-to-clipboard chat output and chunked payload previews
- add a chat helper for emitting copyable links so long snapshots can be copied safely
- make the snapshot chunk preview itself clickable so each chunk can be copied individually when needed

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d74f01f788832f853f58d6fe3d462a