### PR TITLE
Modularize social behaviour routines

### DIFF
--- a/docs/gossip_system.md
+++ b/docs/gossip_system.md
@@ -1,0 +1,75 @@
+# Gossip System Design
+
+## Overview
+- Extend each pet's social memory with a structured gossip ledger that stores rich rumor entries instead of only timestamps.
+- Rumors influence emotions and surface contextual cues so the player experiences flavorful chatter that feels grounded in pet interactions.
+- Same-species exchanges transmit vivid, high-confidence stories, while cross-species encounters mostly convey mood and partial information.
+
+## Data Model
+- Introduce `PetGossipLedger` to live alongside existing `PetComponent` state data.
+- Ledger holds `RumorEntry` records with fields such as:
+  - `topicId`
+  - `intensity`
+  - `confidence`
+  - `lastHeardTick`
+  - `sourceEntityId`
+  - Optional `understoodAs` paraphrase for cross-species misinterpretations
+- Provide helpers on `PetComponent`:
+  - `getGossipLedger()`
+  - `recordRumor(topic, strength, currentTick, source)`
+  - `streamRumors()`/`hasRumor(topic)` for quick queries
+  - `decayRumors(long currentTick)` to fade stale entries
+- Persist ledger via dedicated NBT compound (`"gossipLedger"`) inside `writeToNbt`/`readFromNbt`.
+
+## Gossip Triggers & Events
+### Socialization Circles (Pack Gossip)
+1. Use existing neighbor analytics in `applySocialEffects(...)` to detect when pets form a small or large pack.
+2. Fire a short-lived `GOSSIP_CIRCLE` task on each participant when the pack branch activates.
+3. Choose a storyteller via bond strength or age cached in `PetSocialData`.
+4. While active, the leader pushes fresh rumors into nearby ledgers, emits contextual cues, then lets pets drift back to normal tasks.
+
+### Ritualized Gossip Gatherings
+- **Nightly Campfire Circle**
+  1. Detection: scan for shared points of interest (POI) tagged as `campfire_hub` or for an active campfire block within the pack radius during dusk/night ticks.
+  2. Behavior: enqueue a `GOSSIP_CIRCLE_CAMPFIRE` variant that keeps pets seated/loitering for a few seconds while the storyteller retells high-trust rumors with lingering warmth.
+  3. Player cues: trigger `EmotionContextCues.sendCue(petsplus.emotion_cue.social.gossip.cozy_fire)` paired with relaxed/confident emotions so players read it as bedtime chatter.
+
+- **Communal Feeding Banter**
+  1. Detection: whenever multiple pets share a feeding trough, bowl, or owner-thrown food item tagged with a shared POI, mark the moment as a feeding ritual.
+  2. Behavior: spawn a `GOSSIP_FEEDING` task that piggybacks on eating animations while swapping recent practical rumors (e.g., danger, resource finds) and prioritizing high-intensity entries.
+  3. Player cues: surface lively/alert emotion mixes—pride for the teller, curiosity for listeners—so the scene reads as animated table talk.
+
+- **Grooming & Rest Huddle**
+  1. Detection: watch for scheduled rest periods or simultaneous use of grooming interactions (existing calm emotes) inside dens marked with a `resting_spot` POI.
+  2. Behavior: kick off a `GOSSIP_GROOMING` task that emphasizes low-intensity, high-confidence whispers while pets idle, reinforcing bonds and slowly reinforcing rumor confidence.
+  3. Player cues: emit soft, affectionate emotions (contentment, trust) with a cue like `petsplus.emotion_cue.social.gossip.grooming` to signal gentle, intimate sharing.
+
+Each ritualized variant inherits the base circle mechanics but swaps contextual cues, emotion blends, and rumor weighting to match the activity so the player intuitively understands why pets gathered.
+
+### Walk-Up Whisper (One-on-One Gossip)
+1. Hook into `processAdvancedSocialDynamics` reunion/first-meeting logic that already runs every 120 ticks.
+2. On meeting, schedule a `WHISPER` exchange: merge relevant rumor entries, apply emotional reactions, reset `social_memory_*` data, and allow pets to continue their preexisting goals.
+
+### Rumor Creation Hooks
+- Define canonical gossip topics (enum/registry) for notable events such as owner health, biome discoveries, or first-time meetings.
+- In systems like `EmotionsEventHandler.addSocialAwarenessTriggers` and other notable triggers, record new rumors via the ledger helpers.
+
+## Species-Based Comprehension
+- Maintain a `GossipDialect` map keyed by `EntityType` that scores comprehension per topic.
+- Same-species pets receive full clarity and intensity.
+- Closely related species get dampened details; unrelated entities mostly feel the emotional tone.
+- When propagating cross-species rumors, store dampened/paraphrased variants while still applying mood contagion for emotional bleed-through.
+
+## Feedback & Decay
+- Model a rumor lifecycle with explicit stages:
+  - **Spark:** rumor is first recorded; intensity spikes while confidence starts low. Trigger excited/surprised emotions and cues like `...gossip.new`.
+  - **Circulate:** repeated exchanges increase confidence when corroborated, slightly dropping intensity to reflect normalization. Pets show curious/animated moods.
+  - **Confirm/Dispel:** ledger comparisons during exchanges push confidence to 1.0 when multiple sources agree (rewarding consensus with celebratory cues), or damp intensity and confidence sharply when contradictions arise (triggering doubtful/skeptical emotions).
+- During gossip exchange helpers, compare overlapping rumor entries from both ledgers to automatically bump confidence when stories align or flag `contradicted` status when they clash.
+- When contradictions surface, emit debunk cues (e.g., `petsplus.emotion_cue.social.gossip.debunked`) and apply confusion/embarrassment moods so players notice the rumor collapsing.
+- When confirmation occurs, push pride/reassurance emotions and celebratory cues (e.g., `...gossip.confirmed`) so validation feels rewarding.
+- During player tick handling (or a scheduled task), call `decayRumors` to naturally expire old gossip and throttle repeated chatter, resetting rumors to idle/expired state once confidence and intensity fall below thresholds.
+
+## Debugging & Tuning
+- Consider a `/petsplus gossip <pet>` debug command to dump active rumors for balancing and QA.
+- Watch ledger sizes and decay timing to keep performance stable and avoid runaway rumor proliferation.

--- a/src/main/java/woflo/petsplus/behavior/social/PackCircleRoutine.java
+++ b/src/main/java/woflo/petsplus/behavior/social/PackCircleRoutine.java
@@ -1,0 +1,217 @@
+package woflo.petsplus.behavior.social;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.text.Text;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.events.EmotionContextCues;
+import woflo.petsplus.state.PetSwarmIndex;
+
+/**
+ * Handles pack-scale social observations (group size, age mix, proximity) and
+ * mood contagion effects.
+ */
+public class PackCircleRoutine implements SocialBehaviorRoutine {
+
+    private static final double PACK_SCAN_RADIUS = 8.0;
+
+    @Override
+    public boolean shouldRun(SocialContextSnapshot context) {
+        return true;
+    }
+
+    @Override
+    public void gatherContext(SocialContextSnapshot context, PetSwarmIndex swarm, long currentTick) {
+        PetSocialData self = context.petData();
+        final long selfAge = self.age();
+        PackObservations observations = new PackObservations();
+
+        swarm.forEachNeighbor(context.pet(), context.component(), PACK_SCAN_RADIUS, (entry, distance) -> {
+            if (distance > 64) {
+                return;
+            }
+
+            PetSocialData other = context.getOrCreateNeighborData(entry, currentTick);
+            observations.nearbyCount++;
+
+            long otherAge = other.age();
+            if (otherAge > selfAge * 2) {
+                observations.hasEldest = true;
+            } else if (otherAge > selfAge) {
+                observations.hasOlder = true;
+            } else if (otherAge < Math.max(1L, selfAge) / 2L) {
+                observations.hasYounger = true;
+            }
+
+            double ageRatio = (double) otherAge / Math.max(selfAge, 1L);
+            if (Math.abs(ageRatio - 1.0) <= 0.2) {
+                observations.hasSimilarAge = true;
+            }
+            if (otherAge < 24000) {
+                observations.hasNewborn = true;
+            }
+
+            float bondDiff = Math.abs(self.bondStrength() - other.bondStrength());
+            if (bondDiff < 0.2f) {
+                observations.strongestResonance = Math.max(observations.strongestResonance,
+                    Math.min(self.bondStrength(), other.bondStrength()));
+            }
+
+            if (distance < observations.closestDistance) {
+                observations.closestDistance = distance;
+                observations.closestData = other;
+            }
+
+            if (other.currentMood() != null) {
+                observations.moodNeighbors.add(other);
+            }
+        });
+
+        context.setPackObservations(observations.nearbyCount, observations.hasOlder, observations.hasYounger,
+            observations.hasEldest, observations.hasSimilarAge, observations.hasNewborn,
+            observations.strongestResonance, observations.closestData, observations.closestDistance);
+        context.setMoodNeighbors(observations.moodNeighbors);
+    }
+
+    @Override
+    public void applyEffects(SocialContextSnapshot context) {
+        if (!context.hasPackContext()) {
+            return;
+        }
+
+        applyMoodContagion(context);
+        applyPackEmotions(context);
+    }
+
+    private void applyMoodContagion(SocialContextSnapshot context) {
+        PetComponent component = context.component();
+        for (PetSocialData neighbor : context.moodNeighbors()) {
+            PetComponent.Mood mood = neighbor.currentMood();
+            if (mood == null) {
+                continue;
+            }
+            float strength = calculateContagionStrength(context.petData(), neighbor,
+                context.hasEldestPet(), context.hasSimilarAge(), context.strongestBondResonance());
+            switch (mood) {
+                case HAPPY -> component.pushEmotion(PetComponent.Emotion.CHEERFUL, strength);
+                case PLAYFUL -> component.pushEmotion(PetComponent.Emotion.GLEE, strength);
+                case CURIOUS -> component.pushEmotion(PetComponent.Emotion.CURIOUS, strength);
+                case BONDED -> component.pushEmotion(PetComponent.Emotion.UBUNTU, strength);
+                case CALM -> component.pushEmotion(PetComponent.Emotion.LAGOM, strength + 0.01f);
+                case PASSIONATE -> component.pushEmotion(PetComponent.Emotion.KEFI, strength);
+                case YUGEN -> component.pushEmotion(PetComponent.Emotion.YUGEN, strength);
+                case FOCUSED -> component.pushEmotion(PetComponent.Emotion.FOCUSED, strength);
+                case SISU -> component.pushEmotion(PetComponent.Emotion.SISU, strength);
+                case SAUDADE -> component.pushEmotion(PetComponent.Emotion.SAUDADE, strength);
+                case PROTECTIVE -> component.pushEmotion(PetComponent.Emotion.PROTECTIVENESS, strength);
+                case RESTLESS -> component.pushEmotion(PetComponent.Emotion.RESTLESS, strength);
+                case AFRAID -> component.pushEmotion(PetComponent.Emotion.ANGST, strength + 0.01f);
+                case ANGRY -> component.pushEmotion(PetComponent.Emotion.FRUSTRATION, strength);
+            }
+        }
+    }
+
+    private float calculateContagionStrength(PetSocialData self, PetSocialData other,
+                                             boolean hasEldestPet, boolean hasSimilarAge,
+                                             float strongestBondResonance) {
+        float strength = 0.02f;
+        if (self.age() < 72000) {
+            strength += 0.01f;
+        }
+        if (hasEldestPet && other.age() > self.age() * 2) {
+            strength += 0.015f;
+        }
+        if (hasSimilarAge) {
+            strength += 0.005f;
+        }
+        if (strongestBondResonance > 0.8f) {
+            strength += 0.01f;
+        }
+        return strength;
+    }
+
+    private void applyPackEmotions(SocialContextSnapshot context) {
+        PetComponent component = context.component();
+        PetSocialData self = context.petData();
+        long petAge = self.age();
+        int nearbyCount = context.nearbyPetCount();
+        switch (nearbyCount) {
+            case 0 -> {
+                PetComponent.Mood currentMood = component.getCurrentMood();
+                if (currentMood != PetComponent.Mood.CALM && petAge > 48000) {
+                    float lonelinessStrength = petAge > 168000 ? 0.05f : 0.03f;
+                    component.pushEmotion(PetComponent.Emotion.FERNWEH, lonelinessStrength);
+                    component.pushEmotion(PetComponent.Emotion.SAUDADE, lonelinessStrength * 0.6f);
+                    if (context.tryMarkBeat("social_lonely", 300)) {
+                        EmotionContextCues.sendCue(context.owner(),
+                            "social.lonely." + context.pet().getUuidAsString(),
+                            Text.translatable("petsplus.emotion_cue.social.lonely", context.pet().getDisplayName()),
+                            300);
+                    }
+                }
+            }
+            case 1 -> {
+                component.pushEmotion(PetComponent.Emotion.UBUNTU, 0.04f);
+                component.pushEmotion(PetComponent.Emotion.SOBREMESA, 0.03f);
+                if (context.strongestBondResonance() > 0.7f) {
+                    component.pushEmotion(PetComponent.Emotion.HIRAETH, 0.02f);
+                }
+                if (context.tryMarkBeat("social_pair", 400)) {
+                    EmotionContextCues.sendCue(context.owner(),
+                        "social.pair." + context.pet().getUuidAsString(),
+                        Text.translatable("petsplus.emotion_cue.social.pair", context.pet().getDisplayName()),
+                        400);
+                }
+            }
+            default -> {
+                if (nearbyCount <= 3) {
+                    component.pushEmotion(PetComponent.Emotion.SOBREMESA, 0.06f);
+                    component.pushEmotion(PetComponent.Emotion.PROTECTIVENESS, 0.04f);
+                    if (context.hasSimilarAge()) {
+                        component.pushEmotion(PetComponent.Emotion.GLEE, 0.03f);
+                    }
+                } else {
+                    component.pushEmotion(PetComponent.Emotion.KEFI, 0.05f);
+                    component.pushEmotion(PetComponent.Emotion.PROTECTIVENESS, 0.07f);
+                    component.pushEmotion(PetComponent.Emotion.PRIDE, 0.04f);
+                }
+            }
+        }
+
+        if (context.hasEldestPet() && context.tryMarkBeat("social_eldest", 400)) {
+            component.pushEmotion(PetComponent.Emotion.MONO_NO_AWARE, 0.05f);
+            component.pushEmotion(PetComponent.Emotion.HIRAETH, 0.03f);
+            EmotionContextCues.sendCue(context.owner(),
+                "social.eldest." + context.pet().getUuidAsString(),
+                Text.translatable("petsplus.emotion_cue.social.eldest", context.pet().getDisplayName()),
+                400);
+        } else if (context.hasOlderPet() && context.tryMarkBeat("social_elder", 350)) {
+            component.pushEmotion(PetComponent.Emotion.MONO_NO_AWARE, 0.03f);
+            component.pushEmotion(PetComponent.Emotion.FOCUSED, 0.02f);
+            EmotionContextCues.sendCue(context.owner(),
+                "social.elder." + context.pet().getUuidAsString(),
+                Text.translatable("petsplus.emotion_cue.social.elder", context.pet().getDisplayName()),
+                350);
+        }
+
+        if (context.closestPetData() != null && context.closestDistance() <= 4
+            && context.tryMarkBeat("social_intimate", 200)) {
+            component.pushEmotion(PetComponent.Emotion.UBUNTU, 0.02f);
+        }
+    }
+
+    private static final class PackObservations {
+        int nearbyCount;
+        boolean hasOlder;
+        boolean hasYounger;
+        boolean hasEldest;
+        boolean hasSimilarAge;
+        boolean hasNewborn;
+        float strongestResonance;
+        double closestDistance = Double.MAX_VALUE;
+        PetSocialData closestData;
+        final List<PetSocialData> moodNeighbors = new ArrayList<>();
+    }
+}

--- a/src/main/java/woflo/petsplus/behavior/social/PetSocialData.java
+++ b/src/main/java/woflo/petsplus/behavior/social/PetSocialData.java
@@ -1,0 +1,80 @@
+package woflo.petsplus.behavior.social;
+
+import net.minecraft.entity.mob.MobEntity;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetSwarmIndex;
+
+/**
+ * Lightweight cache of neighbour traits used during social behaviour passes.
+ */
+public final class PetSocialData {
+
+    private final MobEntity pet;
+    private final PetComponent component;
+    private final long age;
+    private final float bondStrength;
+    private final double x;
+    private final double y;
+    private final double z;
+    private final PetComponent.Mood currentMood;
+
+    public PetSocialData(PetSwarmIndex.SwarmEntry entry, long currentTick) {
+        this(entry.pet(), entry.component(), currentTick, entry.x(), entry.y(), entry.z());
+    }
+
+    public PetSocialData(MobEntity pet, PetComponent component, long currentTick) {
+        this(pet, component, currentTick, pet.getX(), pet.getY(), pet.getZ());
+    }
+
+    private PetSocialData(MobEntity pet, PetComponent component, long currentTick,
+                          double x, double y, double z) {
+        this.pet = pet;
+        this.component = component;
+        this.age = Math.max(0, currentTick - component.getTamedTick());
+        this.bondStrength = component.getBondStrength();
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.currentMood = component.getCurrentMood();
+    }
+
+    public MobEntity pet() {
+        return pet;
+    }
+
+    public PetComponent component() {
+        return component;
+    }
+
+    public long age() {
+        return age;
+    }
+
+    public float bondStrength() {
+        return bondStrength;
+    }
+
+    public double x() {
+        return x;
+    }
+
+    public double y() {
+        return y;
+    }
+
+    public double z() {
+        return z;
+    }
+
+    public PetComponent.Mood currentMood() {
+        return currentMood;
+    }
+
+    public double squaredDistanceTo(PetSocialData other) {
+        double dx = this.x - other.x;
+        double dy = this.y - other.y;
+        double dz = this.z - other.z;
+        return (dx * dx) + (dy * dy) + (dz * dz);
+    }
+}

--- a/src/main/java/woflo/petsplus/behavior/social/SocialBehaviorRoutine.java
+++ b/src/main/java/woflo/petsplus/behavior/social/SocialBehaviorRoutine.java
@@ -1,0 +1,28 @@
+package woflo.petsplus.behavior.social;
+
+import woflo.petsplus.state.PetSwarmIndex;
+
+/**
+ * Defines the lifecycle for modular social behaviour routines. Each routine
+ * can gather the context it needs, then emit mood or ledger effects without
+ * editing the central handler.
+ */
+public interface SocialBehaviorRoutine {
+
+    /**
+     * Determines whether the routine should execute for the current snapshot.
+     */
+    boolean shouldRun(SocialContextSnapshot context);
+
+    /**
+     * Collects any neighbour or environmental context required before
+     * applying effects.
+     */
+    void gatherContext(SocialContextSnapshot context, PetSwarmIndex swarm, long currentTick);
+
+    /**
+     * Applies the behavioural effects (emotions, cues, ledger updates) based on
+     * the previously gathered context.
+     */
+    void applyEffects(SocialContextSnapshot context);
+}

--- a/src/main/java/woflo/petsplus/behavior/social/SocialContextSnapshot.java
+++ b/src/main/java/woflo/petsplus/behavior/social/SocialContextSnapshot.java
@@ -1,0 +1,209 @@
+package woflo.petsplus.behavior.social;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetSwarmIndex;
+
+/**
+ * Simple data carrier passed to social behaviour routines so they can pull the
+ * information they need without touching the {@link PetComponent} state map
+ * directly.
+ */
+public class SocialContextSnapshot {
+
+    private final MobEntity pet;
+    private final PetComponent component;
+    private final ServerPlayerEntity owner;
+    private final ServerWorld world;
+    private final long currentTick;
+    private final PetSocialData petData;
+    private final Map<MobEntity, PetSocialData> petDataCache;
+
+    private int nearbyPetCount;
+    private boolean hasOlderPet;
+    private boolean hasYoungerPet;
+    private boolean hasEldestPet;
+    private boolean hasSimilarAge;
+    private boolean hasNewbornPet;
+    private float strongestBondResonance;
+    private PetSocialData closestPetData;
+    private double closestDistance = Double.MAX_VALUE;
+    private boolean packContextComputed;
+
+    private List<PetSocialData> moodNeighbors = Collections.emptyList();
+    private List<NeighborSample> nearestNeighbors = Collections.emptyList();
+
+    public SocialContextSnapshot(MobEntity pet, PetComponent component,
+                                 ServerPlayerEntity owner, ServerWorld world,
+                                 long currentTick, PetSocialData petData,
+                                 Map<MobEntity, PetSocialData> petDataCache) {
+        this.pet = Objects.requireNonNull(pet, "pet");
+        this.component = Objects.requireNonNull(component, "component");
+        this.owner = owner;
+        this.world = world;
+        this.currentTick = currentTick;
+        this.petData = Objects.requireNonNull(petData, "petData");
+        this.petDataCache = Objects.requireNonNull(petDataCache, "petDataCache");
+    }
+
+    public MobEntity pet() {
+        return pet;
+    }
+
+    public PetComponent component() {
+        return component;
+    }
+
+    public ServerPlayerEntity owner() {
+        return owner;
+    }
+
+    public ServerWorld world() {
+        return world;
+    }
+
+    public long currentTick() {
+        return currentTick;
+    }
+
+    public PetSocialData petData() {
+        return petData;
+    }
+
+    public PetSocialData getOrCreateNeighborData(PetSwarmIndex.SwarmEntry entry, long tick) {
+        return petDataCache.computeIfAbsent(entry.pet(), key -> new PetSocialData(entry, tick));
+    }
+
+    public PetSocialData getOrCreateNeighborData(MobEntity neighbor, PetComponent neighborComponent, long tick) {
+        return petDataCache.computeIfAbsent(neighbor, key -> new PetSocialData(neighbor, neighborComponent, tick));
+    }
+
+    public void setPackObservations(int nearbyPetCount, boolean hasOlderPet, boolean hasYoungerPet,
+                                    boolean hasEldestPet, boolean hasSimilarAge, boolean hasNewbornPet,
+                                    float strongestBondResonance, PetSocialData closestPetData,
+                                    double closestDistance) {
+        this.nearbyPetCount = nearbyPetCount;
+        this.hasOlderPet = hasOlderPet;
+        this.hasYoungerPet = hasYoungerPet;
+        this.hasEldestPet = hasEldestPet;
+        this.hasSimilarAge = hasSimilarAge;
+        this.hasNewbornPet = hasNewbornPet;
+        this.strongestBondResonance = strongestBondResonance;
+        this.closestPetData = closestPetData;
+        this.closestDistance = closestDistance;
+        this.packContextComputed = true;
+    }
+
+    public boolean hasPackContext() {
+        return packContextComputed;
+    }
+
+    public int nearbyPetCount() {
+        return nearbyPetCount;
+    }
+
+    public boolean hasOlderPet() {
+        return hasOlderPet;
+    }
+
+    public boolean hasYoungerPet() {
+        return hasYoungerPet;
+    }
+
+    public boolean hasEldestPet() {
+        return hasEldestPet;
+    }
+
+    public boolean hasSimilarAge() {
+        return hasSimilarAge;
+    }
+
+    public boolean hasNewbornPet() {
+        return hasNewbornPet;
+    }
+
+    public float strongestBondResonance() {
+        return strongestBondResonance;
+    }
+
+    public PetSocialData closestPetData() {
+        return closestPetData;
+    }
+
+    public double closestDistance() {
+        return closestDistance;
+    }
+
+    public void setMoodNeighbors(List<PetSocialData> neighbors) {
+        this.moodNeighbors = List.copyOf(neighbors);
+    }
+
+    public List<PetSocialData> moodNeighbors() {
+        return moodNeighbors;
+    }
+
+    public void setNearestNeighbors(List<NeighborSample> nearestNeighbors) {
+        this.nearestNeighbors = List.copyOf(nearestNeighbors);
+    }
+
+    public List<NeighborSample> nearestNeighbors() {
+        return nearestNeighbors;
+    }
+
+    public boolean tryMarkBeat(String key, long interval) {
+        String stateKey = "species_" + key;
+        Long last = component.getStateData(stateKey, Long.class);
+        if (last != null && currentTick - last < interval) {
+            return false;
+        }
+        component.setStateData(stateKey, currentTick);
+        return true;
+    }
+
+    public void resetTransientState() {
+        this.nearbyPetCount = 0;
+        this.hasOlderPet = false;
+        this.hasYoungerPet = false;
+        this.hasEldestPet = false;
+        this.hasSimilarAge = false;
+        this.hasNewbornPet = false;
+        this.strongestBondResonance = 0f;
+        this.closestPetData = null;
+        this.closestDistance = Double.MAX_VALUE;
+        this.packContextComputed = false;
+        this.moodNeighbors = Collections.emptyList();
+        this.nearestNeighbors = Collections.emptyList();
+    }
+
+    public static final class NeighborSample {
+        private final MobEntity pet;
+        private final PetSocialData data;
+        private final double squaredDistance;
+
+        public NeighborSample(MobEntity pet, PetSocialData data, double squaredDistance) {
+            this.pet = pet;
+            this.data = data;
+            this.squaredDistance = squaredDistance;
+        }
+
+        public MobEntity pet() {
+            return pet;
+        }
+
+        public PetSocialData data() {
+            return data;
+        }
+
+        public double squaredDistance() {
+            return squaredDistance;
+        }
+    }
+}

--- a/src/main/java/woflo/petsplus/behavior/social/WhisperRoutine.java
+++ b/src/main/java/woflo/petsplus/behavior/social/WhisperRoutine.java
@@ -1,0 +1,104 @@
+package woflo.petsplus.behavior.social;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.text.Text;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.events.EmotionContextCues;
+import woflo.petsplus.state.PetSwarmIndex;
+
+/**
+ * Handles intimate one-on-one social moments such as greetings and empathy
+ * checks. Runs on a slower cadence to match the original throttling logic.
+ */
+public class WhisperRoutine implements SocialBehaviorRoutine {
+
+    private static final double WHISPER_RADIUS = 12.0;
+    private static final long ADVANCED_TICK_INTERVAL = 120L;
+    private static final long REUNION_THRESHOLD = 24000L;
+    private static final String SOCIAL_MEMORY_PREFIX = "social_memory_";
+
+    @Override
+    public boolean shouldRun(SocialContextSnapshot context) {
+        return context.currentTick() % ADVANCED_TICK_INTERVAL == 0;
+    }
+
+    @Override
+    public void gatherContext(SocialContextSnapshot context, PetSwarmIndex swarm, long currentTick) {
+        List<SocialContextSnapshot.NeighborSample> nearest = new ArrayList<>(3);
+        swarm.forEachNeighbor(context.pet(), context.component(), WHISPER_RADIUS, (entry, distance) -> {
+            if (distance > 144) {
+                return;
+            }
+            PetSocialData other = context.getOrCreateNeighborData(entry, currentTick);
+            nearest.add(new SocialContextSnapshot.NeighborSample(entry.pet(), other, distance));
+            nearest.sort(Comparator.comparingDouble(SocialContextSnapshot.NeighborSample::squaredDistance));
+            if (nearest.size() > 3) {
+                nearest.remove(nearest.size() - 1);
+            }
+        });
+        context.setNearestNeighbors(nearest);
+    }
+
+    @Override
+    public void applyEffects(SocialContextSnapshot context) {
+        PetComponent component = context.component();
+        for (SocialContextSnapshot.NeighborSample sample : context.nearestNeighbors()) {
+            MobEntity otherPet = sample.pet();
+            if (otherPet == null) {
+                continue;
+            }
+            PetSocialData otherData = sample.data();
+            String otherPetId = otherPet.getUuidAsString();
+            String socialMemoryKey = SOCIAL_MEMORY_PREFIX + otherPetId;
+
+            Long lastInteraction = component.getStateData(socialMemoryKey, Long.class);
+            boolean isFirstMeeting = lastInteraction == null;
+            boolean isReunion = lastInteraction != null
+                && (context.currentTick() - lastInteraction) > REUNION_THRESHOLD;
+
+            if (isFirstMeeting) {
+                component.pushEmotion(PetComponent.Emotion.CURIOUS, 0.06f);
+                if (context.petData().age() < 72000) {
+                    component.pushEmotion(PetComponent.Emotion.GLEE, 0.04f);
+                    component.pushEmotion(PetComponent.Emotion.PLAYFULNESS, 0.05f);
+                } else {
+                    component.pushEmotion(PetComponent.Emotion.VIGILANT, 0.03f);
+                }
+                component.setStateData(socialMemoryKey, context.currentTick());
+
+                if (context.tryMarkBeat("first_meeting_" + otherPetId, 800)) {
+                    EmotionContextCues.sendCue(context.owner(),
+                        "social.first_meeting." + context.pet().getUuidAsString(),
+                        Text.translatable("petsplus.emotion_cue.social.first_meeting",
+                            context.pet().getDisplayName(), otherPet.getDisplayName()),
+                        400);
+                }
+            } else if (isReunion) {
+                long separationTime = context.currentTick() - lastInteraction;
+                float reunionStrength = Math.min(0.08f, separationTime / 120000f);
+
+                component.pushEmotion(PetComponent.Emotion.GLEE, reunionStrength);
+                component.pushEmotion(PetComponent.Emotion.LOYALTY, reunionStrength * 0.7f);
+                component.setStateData(socialMemoryKey, context.currentTick());
+            }
+
+            PetComponent.Mood mood = otherData.currentMood();
+            if (mood == PetComponent.Mood.AFRAID || mood == PetComponent.Mood.ANGRY) {
+                float empathyStrength = context.petData().bondStrength() * 0.04f;
+                component.pushEmotion(PetComponent.Emotion.EMPATHY, empathyStrength);
+                if (context.tryMarkBeat("empathy_" + otherPetId, 600)) {
+                    EmotionContextCues.sendCue(context.owner(),
+                        "social.empathy." + context.pet().getUuidAsString(),
+                        Text.translatable("petsplus.emotion_cue.social.empathy",
+                            context.pet().getDisplayName(), otherPet.getDisplayName()),
+                        300);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a social behaviour package with a routine interface, reusable context snapshot, and cached neighbour data helpers
- implement pack-circle and whisper routines so group and one-on-one interactions encapsulate their cues and emotion pushes
- refactor EmotionsEventHandler to iterate the registered routines and reuse the simplified hierarchy check after each pass

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d764bee424832fa2fcce1f23f55a70