### PR TITLE
Guard grounded sitting transforms on invalid mobs

### DIFF
--- a/src/main/java/woflo/petsplus/mixin/FrogEntityMixin.java
+++ b/src/main/java/woflo/petsplus/mixin/FrogEntityMixin.java
@@ -10,16 +10,23 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import woflo.petsplus.taming.ComponentBackedTameable;
 import woflo.petsplus.taming.ComponentBackedTameableBridge;
+import woflo.petsplus.taming.SittingOffsetTracker;
 
 /**
  * Shares the Pets+ tameable bridge logic with frogs so they act like other companions.
  */
 @Mixin(FrogEntity.class)
-public abstract class FrogEntityMixin extends AnimalEntity implements ComponentBackedTameable {
+public abstract class FrogEntityMixin extends AnimalEntity implements ComponentBackedTameable, SittingOffsetTracker {
+
+    @Unique
+    private static final double petsplus$SIT_OFFSET = 0.1D;
 
     @Unique
     private final ComponentBackedTameableBridge petsplus$bridge =
         new ComponentBackedTameableBridge((MobEntity) (Object) this);
+
+    @Unique
+    private boolean petsplus$sittingOffsetApplied;
 
     protected FrogEntityMixin(EntityType<? extends AnimalEntity> entityType, World world) {
         super(entityType, world);
@@ -35,6 +42,7 @@ public abstract class FrogEntityMixin extends AnimalEntity implements ComponentB
         if (!tamed) {
             this.setAiDisabled(false);
             this.jumping = false;
+            this.petsplus$resetGroundedSitting();
         }
     }
 
@@ -46,6 +54,22 @@ public abstract class FrogEntityMixin extends AnimalEntity implements ComponentB
             this.setVelocity(Vec3d.ZERO);
             this.jumping = false;
         }
+        this.petsplus$syncGroundedSitting(sitting);
+    }
+
+    @Override
+    public double petsplus$getSittingOffset() {
+        return petsplus$SIT_OFFSET;
+    }
+
+    @Override
+    public void petsplus$setSittingOffsetApplied(boolean applied) {
+        this.petsplus$sittingOffsetApplied = applied;
+    }
+
+    @Override
+    public boolean petsplus$hasSittingOffsetApplied() {
+        return this.petsplus$sittingOffsetApplied;
     }
 }
 

--- a/src/main/java/woflo/petsplus/mixin/MobEntityDataMixin.java
+++ b/src/main/java/woflo/petsplus/mixin/MobEntityDataMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import woflo.petsplus.api.entity.PetsplusTameable;
 import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.taming.SittingOffsetTracker;
 
 import java.util.UUID;
 
@@ -47,6 +48,11 @@ public class MobEntityDataMixin {
 
             // Ensure the component is properly registered
             PetComponent.set(entity, component);
+
+            boolean sittingOffsetApplied = component.getStateData("petsplus:sitting_offset", Boolean.class, false);
+            if (entity instanceof SittingOffsetTracker tracker) {
+                tracker.petsplus$setSittingOffsetApplied(sittingOffsetApplied);
+            }
 
             if (entity instanceof PetsplusTameable tameable && !(entity instanceof TameableEntity)) {
                 boolean tamed = component.getStateData("petsplus:tamed", Boolean.class, false);

--- a/src/main/java/woflo/petsplus/mixin/RabbitEntityMixin.java
+++ b/src/main/java/woflo/petsplus/mixin/RabbitEntityMixin.java
@@ -10,16 +10,23 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import woflo.petsplus.taming.ComponentBackedTameable;
 import woflo.petsplus.taming.ComponentBackedTameableBridge;
+import woflo.petsplus.taming.SittingOffsetTracker;
 
 /**
  * Provides tameable state for rabbits using the shared Pets+ bridge helper.
  */
 @Mixin(RabbitEntity.class)
-public abstract class RabbitEntityMixin extends AnimalEntity implements ComponentBackedTameable {
+public abstract class RabbitEntityMixin extends AnimalEntity implements ComponentBackedTameable, SittingOffsetTracker {
+
+    @Unique
+    private static final double petsplus$SIT_OFFSET = 0.1D;
 
     @Unique
     private final ComponentBackedTameableBridge petsplus$bridge =
         new ComponentBackedTameableBridge((MobEntity) (Object) this);
+
+    @Unique
+    private boolean petsplus$sittingOffsetApplied;
 
     protected RabbitEntityMixin(EntityType<? extends AnimalEntity> entityType, World world) {
         super(entityType, world);
@@ -35,6 +42,7 @@ public abstract class RabbitEntityMixin extends AnimalEntity implements Componen
         if (!tamed) {
             this.setAiDisabled(false);
             this.jumping = false;
+            this.petsplus$resetGroundedSitting();
         }
     }
 
@@ -48,6 +56,22 @@ public abstract class RabbitEntityMixin extends AnimalEntity implements Componen
         } else {
             this.jumping = false;
         }
+        this.petsplus$syncGroundedSitting(sitting);
+    }
+
+    @Override
+    public double petsplus$getSittingOffset() {
+        return petsplus$SIT_OFFSET;
+    }
+
+    @Override
+    public void petsplus$setSittingOffsetApplied(boolean applied) {
+        this.petsplus$sittingOffsetApplied = applied;
+    }
+
+    @Override
+    public boolean petsplus$hasSittingOffsetApplied() {
+        return this.petsplus$sittingOffsetApplied;
     }
 }
 

--- a/src/main/java/woflo/petsplus/mixin/TurtleEntityMixin.java
+++ b/src/main/java/woflo/petsplus/mixin/TurtleEntityMixin.java
@@ -1,5 +1,6 @@
 package woflo.petsplus.mixin;
 
+import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.passive.AnimalEntity;
@@ -10,16 +11,23 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import woflo.petsplus.taming.ComponentBackedTameable;
 import woflo.petsplus.taming.ComponentBackedTameableBridge;
+import woflo.petsplus.taming.SittingOffsetTracker;
 
 /**
  * Shares the Pets+ tameable bridge logic with turtles so they align with other companions.
  */
 @Mixin(TurtleEntity.class)
-public abstract class TurtleEntityMixin extends AnimalEntity implements ComponentBackedTameable {
+public abstract class TurtleEntityMixin extends AnimalEntity implements ComponentBackedTameable, SittingOffsetTracker {
+
+    @Unique
+    private static final double petsplus$SIT_OFFSET = 0.1D;
 
     @Unique
     private final ComponentBackedTameableBridge petsplus$bridge =
         new ComponentBackedTameableBridge((MobEntity) (Object) this);
+
+    @Unique
+    private boolean petsplus$sittingOffsetApplied;
 
     protected TurtleEntityMixin(EntityType<? extends AnimalEntity> entityType, World world) {
         super(entityType, world);
@@ -34,6 +42,7 @@ public abstract class TurtleEntityMixin extends AnimalEntity implements Componen
     public void petsplus$afterTameChange(boolean tamed) {
         if (!tamed) {
             this.setAiDisabled(false);
+            this.petsplus$resetGroundedSitting();
         }
     }
 
@@ -44,5 +53,26 @@ public abstract class TurtleEntityMixin extends AnimalEntity implements Componen
             this.getNavigation().stop();
             this.setVelocity(Vec3d.ZERO);
         }
+        this.petsplus$syncGroundedSitting(sitting);
+    }
+
+    @Override
+    public EntityPose petsplus$getSittingPose() {
+        return EntityPose.SWIMMING;
+    }
+
+    @Override
+    public double petsplus$getSittingOffset() {
+        return petsplus$SIT_OFFSET;
+    }
+
+    @Override
+    public void petsplus$setSittingOffsetApplied(boolean applied) {
+        this.petsplus$sittingOffsetApplied = applied;
+    }
+
+    @Override
+    public boolean petsplus$hasSittingOffsetApplied() {
+        return this.petsplus$sittingOffsetApplied;
     }
 }

--- a/src/main/java/woflo/petsplus/taming/SittingOffsetTracker.java
+++ b/src/main/java/woflo/petsplus/taming/SittingOffsetTracker.java
@@ -1,0 +1,88 @@
+package woflo.petsplus.taming;
+
+import net.minecraft.entity.EntityPose;
+import net.minecraft.entity.mob.MobEntity;
+import woflo.petsplus.state.PetComponent;
+
+/**
+ * Tracks whether a mixin-backed pet has already had its synthetic sitting
+ * offset applied and provides helpers to keep the pose/offset in sync in a
+ * single, entity-agnostic place.
+ */
+public interface SittingOffsetTracker {
+
+    double petsplus$getSittingOffset();
+
+    default EntityPose petsplus$getSittingPose() {
+        return EntityPose.SLEEPING;
+    }
+
+    void petsplus$setSittingOffsetApplied(boolean applied);
+
+    boolean petsplus$hasSittingOffsetApplied();
+
+    default void petsplus$syncGroundedSitting(boolean sitting) {
+        MobEntity mob = this.petsplus$asMobEntity();
+
+        EntityPose targetPose = sitting ? this.petsplus$getSittingPose() : EntityPose.STANDING;
+        boolean canTransform = mob.isAlive() && !mob.isRemoved();
+
+        if (canTransform && mob.getPose() != targetPose) {
+            mob.setPose(targetPose);
+            mob.calculateDimensions();
+        }
+
+        if (sitting) {
+            if (!this.petsplus$hasSittingOffsetApplied()) {
+                if (canTransform) {
+                    this.petsplus$shiftY(-this.petsplus$getSittingOffset());
+                }
+                this.petsplus$storeSittingOffset(true);
+            }
+        } else if (this.petsplus$hasSittingOffsetApplied()) {
+            if (canTransform) {
+                this.petsplus$shiftY(this.petsplus$getSittingOffset());
+            }
+            this.petsplus$storeSittingOffset(false);
+        }
+    }
+
+    default void petsplus$resetGroundedSitting() {
+        MobEntity mob = this.petsplus$asMobEntity();
+        boolean canTransform = mob.isAlive() && !mob.isRemoved();
+
+        if (this.petsplus$hasSittingOffsetApplied()) {
+            if (canTransform) {
+                this.petsplus$shiftY(this.petsplus$getSittingOffset());
+            }
+            this.petsplus$storeSittingOffset(false);
+        }
+
+        if (canTransform && mob.getPose() != EntityPose.STANDING) {
+            mob.setPose(EntityPose.STANDING);
+            mob.calculateDimensions();
+        }
+    }
+
+    private MobEntity petsplus$asMobEntity() {
+        return (MobEntity) this;
+    }
+
+    private void petsplus$shiftY(double delta) {
+        MobEntity mob = this.petsplus$asMobEntity();
+        mob.setPosition(mob.getX(), mob.getY() + delta, mob.getZ());
+    }
+
+    private void petsplus$storeSittingOffset(boolean applied) {
+        if (this.petsplus$hasSittingOffsetApplied() == applied) {
+            return;
+        }
+
+        this.petsplus$setSittingOffsetApplied(applied);
+
+        MobEntity mob = this.petsplus$asMobEntity();
+        if (!mob.getWorld().isClient) {
+            PetComponent.getOrCreate(mob).setStateData("petsplus:sitting_offset", applied);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- skip pose and offset transforms when a mixin-backed pet is dead or removed while still keeping its stored state accurate
- avoid redundant component writes by only persisting the sitting offset flag when it actually changes

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68d761d41e10832fae0e5bc0c05663a6