### PR TITLE
Add owner-centric async processing pipeline with safe ability fallbacks

### DIFF
--- a/src/main/java/woflo/petsplus/abilities/AbilityManager.java
+++ b/src/main/java/woflo/petsplus/abilities/AbilityManager.java
@@ -1,6 +1,9 @@
 package woflo.petsplus.abilities;
 
 import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import woflo.petsplus.Petsplus;
 import woflo.petsplus.api.Ability;
@@ -10,8 +13,12 @@ import woflo.petsplus.api.registry.AbilityType;
 import woflo.petsplus.api.registry.PetRoleType;
 import woflo.petsplus.api.registry.PetsPlusRegistries;
 import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetSwarmIndex;
+import woflo.petsplus.state.StateManager;
+import woflo.petsplus.state.processing.OwnerBatchSnapshot;
 
 import java.util.*;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Manages all abilities and their activation for pets.
@@ -19,6 +26,8 @@ import java.util.*;
 public class AbilityManager {
     private static final Map<Identifier, List<Ability>> ROLE_ABILITIES = new HashMap<>();
     private static final Map<Identifier, Ability> ALL_ABILITIES = new HashMap<>();
+    private static final Map<Identifier, RoleAbilityCache> ROLE_EVENT_CACHES = new HashMap<>();
+    private static final Map<Identifier, List<RoleAbilityCache.CompiledAbility>> ROLE_COMPILED_DEFAULTS = new HashMap<>();
 
     /**
      * Initialize the ability system with default abilities.
@@ -33,6 +42,8 @@ public class AbilityManager {
     public static synchronized void reloadFromRegistry() {
         ROLE_ABILITIES.clear();
         ALL_ABILITIES.clear();
+        ROLE_EVENT_CACHES.clear();
+        ROLE_COMPILED_DEFAULTS.clear();
 
         Map<Identifier, Ability> instantiated = new HashMap<>();
         for (AbilityType type : PetsPlusRegistries.abilityTypeRegistry()) {
@@ -47,6 +58,9 @@ public class AbilityManager {
 
         for (PetRoleType roleType : PetsPlusRegistries.petRoleTypeRegistry()) {
             List<Ability> loadout = new ArrayList<>();
+            Map<String, List<Ability>> eventBuckets = new HashMap<>();
+            List<Ability> fallback = new ArrayList<>();
+
             for (Identifier abilityId : roleType.defaultAbilities()) {
                 Ability ability = instantiated.get(abilityId);
                 if (ability == null) {
@@ -54,8 +68,19 @@ public class AbilityManager {
                     continue;
                 }
                 loadout.add(ability);
+
+                String eventKey = resolveEventKey(ability);
+                if (eventKey != null) {
+                    eventBuckets.computeIfAbsent(eventKey, unused -> new ArrayList<>()).add(ability);
+                } else {
+                    fallback.add(ability);
+                }
             }
-            ROLE_ABILITIES.put(roleType.id(), List.copyOf(loadout));
+
+            RoleAbilityCache cache = RoleAbilityCache.build(loadout, eventBuckets, fallback);
+            ROLE_ABILITIES.put(roleType.id(), cache.abilityView());
+            ROLE_EVENT_CACHES.put(roleType.id(), cache);
+            ROLE_COMPILED_DEFAULTS.put(roleType.id(), cache.defaultCompiled());
         }
 
         if (ALL_ABILITIES.isEmpty()) {
@@ -69,41 +94,407 @@ public class AbilityManager {
      * Trigger abilities for a pet based on the given context.
      */
     public static void triggerAbilities(MobEntity pet, TriggerContext context) {
-        if (pet == null) return;
+        if (pet == null) {
+            return;
+        }
 
         PetComponent component = PetComponent.get(pet);
-        if (component == null) return;
+        if (component == null) {
+            return;
+        }
 
         Identifier roleId = component.getRoleId();
-        List<Ability> abilities = ROLE_ABILITIES.get(roleId);
-        if (abilities == null || abilities.isEmpty()) {
+        RoleAbilityCache cache = ROLE_EVENT_CACHES.get(roleId);
+        List<RoleAbilityCache.CompiledAbility> compiledAbilities = cache != null
+            ? cache.compiledAbilitiesForEvent(context.getEventType())
+            : ROLE_COMPILED_DEFAULTS.get(roleId);
+
+        if (compiledAbilities == null || compiledAbilities.isEmpty()) {
             if (PetsPlusRegistries.petRoleTypeRegistry().get(roleId) == null) {
                 Petsplus.LOGGER.warn("Pet {} has role {} without a registered definition; skipping ability triggers.", pet.getUuid(), roleId);
             }
             return;
         }
 
-        // Create a pet-aware context that preserves event data
+        TriggerContext petContext = cloneContextForPet(pet, context);
+        executeCompiledAbilities(component, component.getRoleType(false), compiledAbilities, petContext);
+    }
+
+    /**
+     * Triggers a compiled ability batch for an owner-scoped event by grouping pets by
+     * role and reusing compiled ability metadata for the entire swarm.
+     */
+    public static void triggerAbilitiesForOwnerEvent(ServerWorld world,
+                                                     @Nullable ServerPlayerEntity ownerHint,
+                                                     List<PetComponent> pets,
+                                                     String triggerId,
+                                                     Map<String, Object> eventData) {
+        if (world == null || triggerId == null) {
+            return;
+        }
+        String trimmedTrigger = triggerId.trim();
+        if (trimmedTrigger.isEmpty() || pets == null || pets.isEmpty()) {
+            return;
+        }
+
+        Map<Identifier, RoleAbilityGroup> groups = new HashMap<>();
+        Set<Identifier> skippedRoles = new HashSet<>();
+
+        for (PetComponent component : pets) {
+            if (component == null) {
+                continue;
+            }
+            MobEntity pet = component.getPetEntity();
+            if (pet == null || pet.isRemoved()) {
+                continue;
+            }
+
+            Identifier roleId = component.getRoleId();
+            if (roleId == null) {
+                continue;
+            }
+            if (skippedRoles.contains(roleId)) {
+                continue;
+            }
+
+            RoleAbilityGroup group = groups.get(roleId);
+            if (group == null) {
+                RoleAbilityCache cache = ROLE_EVENT_CACHES.get(roleId);
+                List<RoleAbilityCache.CompiledAbility> compiled = cache != null
+                    ? cache.compiledAbilitiesForEvent(trimmedTrigger)
+                    : ROLE_COMPILED_DEFAULTS.get(roleId);
+                if (compiled == null || compiled.isEmpty()) {
+                    skippedRoles.add(roleId);
+                    continue;
+                }
+                PetRoleType roleType = component.getRoleType(false);
+                if (roleType == null) {
+                    skippedRoles.add(roleId);
+                    continue;
+                }
+                group = new RoleAbilityGroup(roleType, compiled);
+                groups.put(roleId, group);
+            }
+
+            ServerPlayerEntity resolvedOwner = resolveOwner(ownerHint, component);
+            if (resolvedOwner == null) {
+                continue;
+            }
+
+            group.addMember(pet, component, resolvedOwner);
+        }
+
+        if (groups.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> sharedData = eventData == null ? Map.of() : eventData;
+        for (RoleAbilityGroup group : groups.values()) {
+            for (RoleAbilityGroup.Member member : group.members()) {
+                TriggerContext context = new TriggerContext(world, member.pet(), member.owner(), trimmedTrigger);
+                if (!sharedData.isEmpty()) {
+                    context.getEventData().putAll(sharedData);
+                }
+                executeCompiledAbilities(member.component(), group.roleType(), group.compiledAbilities(), context);
+            }
+        }
+    }
+
+    public static AbilityExecutionPlan prepareOwnerExecutionPlan(OwnerBatchSnapshot snapshot,
+                                                                 AbilityTriggerPayload payload) {
+        if (snapshot == null || payload == null) {
+            return AbilityExecutionPlan.empty();
+        }
+        List<OwnerBatchSnapshot.PetSummary> pets = snapshot.pets();
+        if (pets.isEmpty()) {
+            return AbilityExecutionPlan.empty();
+        }
+        String triggerId = payload.eventType();
+        if (triggerId.isEmpty()) {
+            return AbilityExecutionPlan.empty();
+        }
+
+        List<AbilityExecutionPlan.PetExecution> executions = new ArrayList<>();
+
+        for (OwnerBatchSnapshot.PetSummary petSummary : pets) {
+            UUID petUuid = petSummary.petUuid();
+            Identifier roleId = petSummary.roleId();
+            if (petUuid == null || roleId == null) {
+                continue;
+            }
+
+            RoleAbilityCache cache = ROLE_EVENT_CACHES.get(roleId);
+            if (cache == null) {
+                continue;
+            }
+            List<RoleAbilityCache.CompiledAbility> compiled = cache.compiledAbilitiesForEvent(triggerId);
+            if (compiled == null || compiled.isEmpty()) {
+                continue;
+            }
+
+            Map<String, Long> cooldowns = petSummary.cooldowns();
+            executions.add(new AbilityExecutionPlan.PetExecution(petUuid, roleId, compiled, cooldowns));
+        }
+
+        return AbilityExecutionPlan.fromEntries(executions);
+    }
+
+    public static void applyOwnerExecutionPlan(AbilityExecutionPlan plan,
+                                               StateManager stateManager,
+                                               AbilityTriggerPayload payload,
+                                               @Nullable UUID ownerId) {
+        if (plan == null || plan.isEmpty() || stateManager == null) {
+            return;
+        }
+
+        ServerWorld world = stateManager.world();
+        if (world == null) {
+            return;
+        }
+
+        List<PetSwarmIndex.SwarmEntry> swarm = ownerId != null
+            ? stateManager.getSwarmIndex().snapshotOwner(ownerId)
+            : List.of();
+        if (swarm.isEmpty()) {
+            return;
+        }
+
+        long applicationTick = world.getTime();
+
+        Map<UUID, PetComponent> componentsById = new HashMap<>();
+        Map<UUID, MobEntity> entitiesById = new HashMap<>();
+        for (PetSwarmIndex.SwarmEntry entry : swarm) {
+            MobEntity pet = entry.pet();
+            if (pet == null) {
+                continue;
+            }
+            componentsById.put(pet.getUuid(), entry.component());
+            entitiesById.put(pet.getUuid(), pet);
+        }
+
+        ServerPlayerEntity owner = stateManager.findOnlineOwner(ownerId);
+
+        for (AbilityExecutionPlan.PetExecution execution : plan.executions()) {
+            PetComponent component = componentsById.get(execution.petUuid());
+            MobEntity pet = entitiesById.get(execution.petUuid());
+            if (component == null || pet == null || pet.isRemoved()) {
+                continue;
+            }
+
+            Map<String, Long> cooldowns = component.copyCooldownSnapshot();
+            if (cooldowns.isEmpty()) {
+                cooldowns = execution.cooldowns();
+            }
+
+            List<RoleAbilityCache.CompiledAbility> readyAbilities = filterAbilitiesByCooldown(
+                execution.abilities(),
+                cooldowns,
+                applicationTick
+            );
+            if (readyAbilities.isEmpty()) {
+                continue;
+            }
+            TriggerContext context = new TriggerContext(world, pet, owner, payload.eventType());
+            if (payload.hasData()) {
+                context.getEventData().putAll(payload.eventData());
+            }
+            executeCompiledAbilities(component, component.getRoleType(false), readyAbilities, context);
+        }
+    }
+
+    /**
+     * Get all abilities for a specific role.
+     */
+    public static List<Ability> getAbilitiesForRole(Identifier roleId) {
+        return ROLE_ABILITIES.getOrDefault(roleId, Collections.emptyList());
+    }
+
+    /**
+     * Get a specific ability by ID.
+     */
+    public static Ability getAbility(Identifier id) {
+        return ALL_ABILITIES.get(id);
+    }
+
+    private static String resolveEventKey(Ability ability) {
+        if (ability == null) {
+            return null;
+        }
+        if (ability.getTrigger() == null) {
+            return null;
+        }
+        Identifier triggerId = ability.getTrigger().getId();
+        if (triggerId == null) {
+            return null;
+        }
+        String path = triggerId.getPath();
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        return path;
+    }
+
+    private static final class RoleAbilityCache {
+        private final List<Ability> abilityView;
+        private final List<CompiledAbility> defaultCompiled;
+        private final Map<String, List<CompiledAbility>> compiledByEvent;
+
+        private RoleAbilityCache(List<Ability> abilityView,
+                                 List<CompiledAbility> defaultCompiled,
+                                 Map<String, List<CompiledAbility>> compiledByEvent) {
+            this.abilityView = abilityView;
+            this.defaultCompiled = defaultCompiled;
+            this.compiledByEvent = compiledByEvent;
+        }
+
+        static RoleAbilityCache build(List<Ability> loadout,
+                                      Map<String, List<Ability>> eventBuckets,
+                                      List<Ability> fallback) {
+            List<Ability> abilityView = loadout.isEmpty() ? Collections.emptyList() : List.copyOf(loadout);
+            if (eventBuckets.isEmpty() && fallback.isEmpty()) {
+                return new RoleAbilityCache(
+                    abilityView,
+                    compileAbilities(abilityView),
+                    Collections.emptyMap()
+                );
+            }
+
+            IdentityHashMap<Ability, CompiledAbility> compiledCache = new IdentityHashMap<>();
+            List<CompiledAbility> baseline = compileAbilities(abilityView, compiledCache);
+            List<CompiledAbility> fallbackCompiled = compileAbilities(fallback, compiledCache);
+
+            Map<String, List<CompiledAbility>> compiled = new HashMap<>();
+            for (Map.Entry<String, List<Ability>> entry : eventBuckets.entrySet()) {
+                List<Ability> abilities = entry.getValue();
+                if (abilities == null || abilities.isEmpty()) {
+                    continue;
+                }
+                List<CompiledAbility> eventCompiled = compileAbilities(abilities, compiledCache);
+                List<CompiledAbility> merged;
+                if (fallbackCompiled.isEmpty()) {
+                    merged = eventCompiled;
+                } else {
+                    merged = new ArrayList<>(eventCompiled.size() + fallbackCompiled.size());
+                    merged.addAll(eventCompiled);
+                    merged.addAll(fallbackCompiled);
+                    merged = Collections.unmodifiableList(merged);
+                }
+                compiled.put(entry.getKey(), merged);
+            }
+
+            return new RoleAbilityCache(
+                abilityView,
+                baseline,
+                compiled.isEmpty() ? Collections.emptyMap() : Map.copyOf(compiled)
+            );
+        }
+
+        List<Ability> abilityView() {
+            return abilityView;
+        }
+
+        List<CompiledAbility> defaultCompiled() {
+            return defaultCompiled;
+        }
+
+        List<CompiledAbility> compiledAbilitiesForEvent(String eventType) {
+            if (eventType != null) {
+                List<CompiledAbility> abilities = compiledByEvent.get(eventType);
+                if (abilities != null) {
+                    return abilities;
+                }
+            }
+            return defaultCompiled;
+        }
+
+        private static List<CompiledAbility> compileAbilities(List<Ability> abilities) {
+            return compileAbilities(abilities, new IdentityHashMap<>());
+        }
+
+        private static List<CompiledAbility> compileAbilities(List<Ability> abilities,
+                                                              IdentityHashMap<Ability, CompiledAbility> cache) {
+            if (abilities == null || abilities.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<CompiledAbility> compiled = new ArrayList<>(abilities.size());
+            for (Ability ability : abilities) {
+                if (ability == null) {
+                    continue;
+                }
+                CompiledAbility entry = cache.computeIfAbsent(ability, CompiledAbility::from);
+                compiled.add(entry);
+            }
+            if (compiled.isEmpty()) {
+                return Collections.emptyList();
+            }
+            return Collections.unmodifiableList(compiled);
+        }
+
+        static final class CompiledAbility {
+            private final Ability ability;
+            private final String cooldownKey;
+            private final int baseCooldown;
+
+            private CompiledAbility(Ability ability, String cooldownKey, int baseCooldown) {
+                this.ability = ability;
+                this.cooldownKey = cooldownKey;
+                this.baseCooldown = baseCooldown;
+            }
+
+            static CompiledAbility from(Ability ability) {
+                Identifier id = ability.getId();
+                String cooldownKey = id != null ? id.toString() : ability.getClass().getName();
+                int baseCooldown = 0;
+                if (ability.getTrigger() != null) {
+                    baseCooldown = ability.getTrigger().getInternalCooldownTicks();
+                }
+                return new CompiledAbility(ability, cooldownKey, baseCooldown);
+            }
+
+            Ability ability() {
+                return ability;
+            }
+
+            String cooldownKey() {
+                return cooldownKey;
+            }
+
+            int baseCooldown() {
+                return baseCooldown;
+            }
+        }
+    }
+
+    private static TriggerContext cloneContextForPet(MobEntity pet, TriggerContext context) {
         TriggerContext petContext = new TriggerContext(
             context.getWorld(),
             pet,
             context.getOwner(),
             context.getEventType()
         );
-        for (var entry : context.getEventData().entrySet()) {
-            petContext.withData(entry.getKey(), entry.getValue());
+        if (!context.getEventData().isEmpty()) {
+            petContext.getEventData().putAll(context.getEventData());
+        }
+        return petContext;
+    }
+
+    private static void executeCompiledAbilities(PetComponent component,
+                                                 @Nullable PetRoleType roleType,
+                                                 List<RoleAbilityCache.CompiledAbility> compiledAbilities,
+                                                 TriggerContext context) {
+        if (compiledAbilities == null || compiledAbilities.isEmpty()) {
+            return;
         }
 
-        PetRoleType roleType = component.getRoleType(false);
-
-        for (Ability ability : abilities) {
-            String cooldownKey = ability.getId().toString();
+        for (RoleAbilityCache.CompiledAbility entry : compiledAbilities) {
+            Ability ability = entry.ability();
+            String cooldownKey = entry.cooldownKey();
             boolean onCooldown = component.isOnCooldown(cooldownKey);
-            int baseCooldown = ability.getTrigger().getInternalCooldownTicks();
+            int baseCooldown = entry.baseCooldown();
 
             AbilityActivationEvent.Context eventContext = new AbilityActivationEvent.Context(
                 ability,
-                petContext,
+                context,
                 component,
                 roleType,
                 onCooldown,
@@ -122,7 +513,7 @@ public class AbilityManager {
 
             boolean succeeded;
             if (eventContext.shouldRunDefaultExecution()) {
-                succeeded = ability.tryActivate(petContext);
+                succeeded = ability.tryActivate(context);
                 eventContext.setSucceeded(succeeded);
             } else {
                 succeeded = eventContext.didSucceed();
@@ -144,18 +535,140 @@ public class AbilityManager {
         }
     }
 
-    /**
-     * Get all abilities for a specific role.
-     */
-    public static List<Ability> getAbilitiesForRole(Identifier roleId) {
-        return ROLE_ABILITIES.getOrDefault(roleId, Collections.emptyList());
+    @Nullable
+    private static ServerPlayerEntity resolveOwner(@Nullable ServerPlayerEntity ownerHint, PetComponent component) {
+        if (ownerHint != null && !ownerHint.isRemoved()) {
+            return ownerHint;
+        }
+        PlayerEntity fallback = component.getOwner();
+        if (fallback instanceof ServerPlayerEntity serverOwner && !serverOwner.isRemoved()) {
+            return serverOwner;
+        }
+        return null;
     }
 
-    /**
-     * Get a specific ability by ID.
-     */
-    public static Ability getAbility(Identifier id) {
-        return ALL_ABILITIES.get(id);
+    private static List<RoleAbilityCache.CompiledAbility> filterAbilitiesByCooldown(
+        List<RoleAbilityCache.CompiledAbility> compiled,
+        Map<String, Long> cooldowns,
+        long snapshotTick
+    ) {
+        if (compiled == null || compiled.isEmpty()) {
+            return List.of();
+        }
+        if (cooldowns == null || cooldowns.isEmpty()) {
+            return compiled;
+        }
+        List<RoleAbilityCache.CompiledAbility> filtered = new ArrayList<>(compiled.size());
+        for (RoleAbilityCache.CompiledAbility ability : compiled) {
+            Long cooldownEnd = cooldowns.get(ability.cooldownKey());
+            if (cooldownEnd != null && cooldownEnd > snapshotTick) {
+                continue;
+            }
+            filtered.add(ability);
+        }
+        if (filtered.isEmpty()) {
+            return List.of();
+        }
+        if (filtered.size() == compiled.size()) {
+            return compiled;
+        }
+        return List.copyOf(filtered);
+    }
+
+    public static final class AbilityExecutionPlan {
+        private static final AbilityExecutionPlan EMPTY = new AbilityExecutionPlan(List.of());
+
+        private final List<PetExecution> executions;
+
+        private AbilityExecutionPlan(List<PetExecution> executions) {
+            this.executions = executions;
+        }
+
+        static AbilityExecutionPlan empty() {
+            return EMPTY;
+        }
+
+        static AbilityExecutionPlan fromEntries(List<PetExecution> executions) {
+            if (executions == null || executions.isEmpty()) {
+                return EMPTY;
+            }
+            return new AbilityExecutionPlan(List.copyOf(executions));
+        }
+
+        public boolean isEmpty() {
+            return executions.isEmpty();
+        }
+
+        public List<PetExecution> executions() {
+            return executions;
+        }
+
+        public static final class PetExecution {
+            private final UUID petUuid;
+            private final Identifier roleId;
+            private final List<RoleAbilityCache.CompiledAbility> abilities;
+            private final Map<String, Long> cooldowns;
+
+            public PetExecution(UUID petUuid,
+                                 Identifier roleId,
+                                 List<RoleAbilityCache.CompiledAbility> abilities,
+                                 Map<String, Long> cooldowns) {
+                this.petUuid = petUuid;
+                this.roleId = roleId;
+                this.abilities = abilities == null || abilities.isEmpty()
+                    ? List.of()
+                    : List.copyOf(abilities);
+                this.cooldowns = cooldowns == null || cooldowns.isEmpty()
+                    ? Map.of()
+                    : Map.copyOf(cooldowns);
+            }
+
+            public UUID petUuid() {
+                return petUuid;
+            }
+
+            public Identifier roleId() {
+                return roleId;
+            }
+
+            public List<RoleAbilityCache.CompiledAbility> abilities() {
+                return abilities;
+            }
+
+            public Map<String, Long> cooldowns() {
+                return cooldowns;
+            }
+        }
+    }
+
+    private static final class RoleAbilityGroup {
+        private final PetRoleType roleType;
+        private final List<RoleAbilityCache.CompiledAbility> compiledAbilities;
+        private final List<Member> members = new ArrayList<>();
+
+        RoleAbilityGroup(PetRoleType roleType, List<RoleAbilityCache.CompiledAbility> compiledAbilities) {
+            this.roleType = roleType;
+            this.compiledAbilities = compiledAbilities;
+        }
+
+        void addMember(MobEntity pet, PetComponent component, ServerPlayerEntity owner) {
+            members.add(new Member(pet, component, owner));
+        }
+
+        PetRoleType roleType() {
+            return roleType;
+        }
+
+        List<RoleAbilityCache.CompiledAbility> compiledAbilities() {
+            return compiledAbilities;
+        }
+
+        List<Member> members() {
+            return members;
+        }
+
+        private record Member(MobEntity pet, PetComponent component, ServerPlayerEntity owner) {
+        }
     }
 
     /**

--- a/src/main/java/woflo/petsplus/abilities/AbilityTriggerPayload.java
+++ b/src/main/java/woflo/petsplus/abilities/AbilityTriggerPayload.java
@@ -1,0 +1,50 @@
+package woflo.petsplus.abilities;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Payload describing an owner-scoped ability trigger request. Carries the
+ * trigger identifier and any supplemental event data that should be forwarded
+ * to individual pet trigger contexts.
+ */
+public final class AbilityTriggerPayload {
+    private final String eventType;
+    private final Map<String, Object> eventData;
+
+    private AbilityTriggerPayload(String eventType, Map<String, Object> eventData) {
+        this.eventType = eventType;
+        this.eventData = eventData;
+    }
+
+    /**
+     * Creates a payload instance for the given trigger and optional data map.
+     */
+    public static AbilityTriggerPayload of(String eventType, Map<String, Object> data) {
+        String sanitized = Objects.requireNonNull(eventType, "eventType").trim();
+        if (sanitized.isEmpty()) {
+            throw new IllegalArgumentException("Ability trigger event type cannot be blank");
+        }
+        Map<String, Object> copied;
+        if (data == null || data.isEmpty()) {
+            copied = Collections.emptyMap();
+        } else {
+            copied = Collections.unmodifiableMap(new HashMap<>(data));
+        }
+        return new AbilityTriggerPayload(sanitized, copied);
+    }
+
+    public String eventType() {
+        return eventType;
+    }
+
+    public Map<String, Object> eventData() {
+        return eventData;
+    }
+
+    public boolean hasData() {
+        return !eventData.isEmpty();
+    }
+}

--- a/src/main/java/woflo/petsplus/abilities/OwnerAbilityEventBridge.java
+++ b/src/main/java/woflo/petsplus/abilities/OwnerAbilityEventBridge.java
@@ -1,0 +1,164 @@
+package woflo.petsplus.abilities;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.RejectedExecutionException;
+
+import woflo.petsplus.Petsplus;
+import woflo.petsplus.state.StateManager;
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.processing.AsyncProcessingSettings;
+import woflo.petsplus.state.processing.AsyncWorkCoordinator;
+import woflo.petsplus.state.processing.OwnerBatchSnapshot;
+import woflo.petsplus.state.processing.OwnerEventFrame;
+import woflo.petsplus.state.processing.OwnerEventListener;
+import woflo.petsplus.state.processing.OwnerEventType;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Bridges owner-scoped ability trigger events into per-pet ability execution.
+ */
+public final class OwnerAbilityEventBridge implements OwnerEventListener {
+    public static final OwnerAbilityEventBridge INSTANCE = new OwnerAbilityEventBridge();
+
+    @FunctionalInterface
+    interface AbilityExecutor {
+        void trigger(ServerWorld world,
+                     @Nullable ServerPlayerEntity owner,
+                     List<PetComponent> pets,
+                     String triggerId,
+                     Map<String, Object> eventData);
+    }
+
+    private static volatile AbilityExecutor abilityExecutor = AbilityManager::triggerAbilitiesForOwnerEvent;
+
+    private OwnerAbilityEventBridge() {
+    }
+
+    static void setAbilityExecutorForTesting(@Nullable AbilityExecutor executor) {
+        abilityExecutor = executor == null ? AbilityManager::triggerAbilitiesForOwnerEvent : executor;
+    }
+
+    @Override
+    public void onOwnerEvent(OwnerEventFrame frame) {
+        if (frame.eventType() != OwnerEventType.ABILITY_TRIGGER) {
+            return;
+        }
+        AbilityTriggerPayload payload = frame.payload(AbilityTriggerPayload.class);
+        if (payload == null) {
+            return;
+        }
+        String triggerId = payload.eventType();
+        if (triggerId.isEmpty()) {
+            return;
+        }
+        StateManager manager = StateManager.forWorld(frame.world());
+        OwnerBatchSnapshot snapshot = frame.snapshot();
+        boolean asyncEnabled = AsyncProcessingSettings.asyncAbilitiesEnabled();
+        boolean shadowEnabled = AsyncProcessingSettings.asyncAbilitiesShadowEnabled();
+
+        if (asyncEnabled && snapshot != null && snapshot.ownerId() != null) {
+            dispatchAsync(manager, frame, snapshot, payload, triggerId);
+            return;
+        }
+
+        dispatchSynchronously(frame, payload, triggerId);
+
+        if (shadowEnabled && snapshot != null && snapshot.ownerId() != null) {
+            dispatchShadow(manager, snapshot, payload);
+        }
+    }
+
+    private void dispatchAsync(StateManager manager,
+                               OwnerEventFrame frame,
+                               OwnerBatchSnapshot snapshot,
+                               AbilityTriggerPayload payload,
+                               String triggerId) {
+        AsyncWorkCoordinator coordinator = manager.asyncWorkCoordinator();
+        FallbackContext fallback = FallbackContext.capture(frame, payload, triggerId);
+        CompletableFuture<AbilityManager.AbilityExecutionPlan> future = coordinator.submitOwnerBatch(
+            snapshot,
+            snap -> AbilityManager.prepareOwnerExecutionPlan(snap, payload),
+            plan -> AbilityManager.applyOwnerExecutionPlan(plan, manager, payload, snapshot.ownerId())
+        );
+        future.exceptionally(error -> {
+            Throwable cause = unwrap(error);
+            if (cause instanceof RejectedExecutionException) {
+                Petsplus.LOGGER.debug("Async ability execution rejected for {}, falling back to synchronous", triggerId);
+                dispatchSynchronously(fallback);
+            } else {
+                Petsplus.LOGGER.error("Async ability execution failed for {}", triggerId, cause);
+            }
+            return null;
+        });
+    }
+
+    private void dispatchShadow(StateManager manager,
+                                OwnerBatchSnapshot snapshot,
+                                AbilityTriggerPayload payload) {
+        AsyncWorkCoordinator coordinator = manager.asyncWorkCoordinator();
+        coordinator.submitOwnerBatch(
+            snapshot,
+            snap -> AbilityManager.prepareOwnerExecutionPlan(snap, payload),
+            plan -> {
+                if (!plan.isEmpty()) {
+                    Petsplus.LOGGER.trace("Shadow async ability plan prepared for owner {} with {} entries", snapshot.ownerId(), plan.executions().size());
+                }
+            }
+        ).exceptionally(error -> {
+            Throwable cause = unwrap(error);
+            if (!(cause instanceof RejectedExecutionException)) {
+                Petsplus.LOGGER.debug("Shadow async ability computation failed", cause);
+            }
+            return null;
+        });
+    }
+
+    private void dispatchSynchronously(OwnerEventFrame frame,
+                                       AbilityTriggerPayload payload,
+                                       String triggerId) {
+        dispatchSynchronously(FallbackContext.capture(frame, payload, triggerId));
+    }
+
+    private void dispatchSynchronously(FallbackContext context) {
+        try {
+            abilityExecutor.trigger(
+                context.world(),
+                context.owner(),
+                context.pets(),
+                context.triggerId(),
+                context.eventData()
+            );
+        } catch (Exception ex) {
+            Petsplus.LOGGER.error("Failed to trigger owner ability batch for {}", context.triggerId(), ex);
+        }
+    }
+
+    private static Throwable unwrap(Throwable error) {
+        if (error instanceof CompletionException completion && completion.getCause() != null) {
+            return completion.getCause();
+        }
+        return error;
+    }
+
+    private record FallbackContext(ServerWorld world,
+                                   @Nullable ServerPlayerEntity owner,
+                                   List<PetComponent> pets,
+                                   String triggerId,
+                                   Map<String, Object> eventData) {
+        private static FallbackContext capture(OwnerEventFrame frame,
+                                               AbilityTriggerPayload payload,
+                                               String triggerId) {
+            List<PetComponent> framePets = frame.pets();
+            List<PetComponent> copiedPets = framePets.isEmpty() ? List.of() : List.copyOf(framePets);
+            Map<String, Object> data = payload.eventData().isEmpty() ? Map.of() : payload.eventData();
+            return new FallbackContext(frame.world(), frame.owner(), copiedPets, triggerId, data);
+        }
+    }
+}

--- a/src/main/java/woflo/petsplus/roles/support/SupportPotionVacuumManager.java
+++ b/src/main/java/woflo/petsplus/roles/support/SupportPotionVacuumManager.java
@@ -71,14 +71,21 @@ public final class SupportPotionVacuumManager {
     }
 
     public List<ItemEntity> collectPotionsNearby(MobEntity pet, double radius) {
-        if (!(pet.getWorld() instanceof ServerWorld serverWorld) || radius <= 0) {
+        if (!(pet.getWorld() instanceof ServerWorld serverWorld)) {
             return Collections.emptyList();
         }
-        WorldCache cache = worldCaches.get(serverWorld);
+        return collectPotionsNearby(serverWorld, pet.getPos(), radius);
+    }
+
+    public List<ItemEntity> collectPotionsNearby(ServerWorld world, Vec3d center, double radius) {
+        if (world == null || radius <= 0) {
+            return Collections.emptyList();
+        }
+        WorldCache cache = worldCaches.get(world);
         if (cache == null) {
             return Collections.emptyList();
         }
-        return cache.collect(pet.getPos(), radius);
+        return cache.collect(center, radius);
     }
 
     private static boolean isPotionStack(ItemEntity entity) {

--- a/src/main/java/woflo/petsplus/state/PetWorkScheduler.java
+++ b/src/main/java/woflo/petsplus/state/PetWorkScheduler.java
@@ -133,4 +133,15 @@ public final class PetWorkScheduler {
             consumer.accept(task);
         }
     }
+
+    public synchronized void clear() {
+        for (EnumMap<TaskType, ScheduledTask> tasks : tasksByComponent.values()) {
+            for (ScheduledTask task : tasks.values()) {
+                task.cancelled = true;
+                task.component.onTaskUnschedule(task.type);
+            }
+        }
+        tasksByComponent.clear();
+        buckets.clear();
+    }
 }

--- a/src/main/java/woflo/petsplus/state/StateManager.java
+++ b/src/main/java/woflo/petsplus/state/StateManager.java
@@ -1,16 +1,21 @@
 package woflo.petsplus.state;
 
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Vec3d;
 import org.jetbrains.annotations.Nullable;
 import woflo.petsplus.Petsplus;
 import woflo.petsplus.api.TriggerContext;
 import woflo.petsplus.api.registry.PetRoleType;
 import woflo.petsplus.api.registry.PetsPlusRegistries;
+import woflo.petsplus.abilities.AbilityTriggerPayload;
+import woflo.petsplus.abilities.OwnerAbilityEventBridge;
 import woflo.petsplus.effects.AuraTargetResolver;
 import woflo.petsplus.effects.PetsplusEffectManager;
 import woflo.petsplus.effects.ProjectileDrForOwnerEffect;
@@ -19,14 +24,39 @@ import woflo.petsplus.events.EmotionContextCues;
 import woflo.petsplus.roles.support.SupportPotionUtils;
 import woflo.petsplus.roles.support.SupportPotionVacuumManager;
 import woflo.petsplus.mood.MoodService;
+import woflo.petsplus.mood.EmotionStimulusBus;
 import woflo.petsplus.ui.CooldownParticleManager;
 import woflo.petsplus.util.EntityTagUtil;
+import woflo.petsplus.state.processing.AsyncProcessingSettings;
+import woflo.petsplus.state.processing.AsyncProcessingTelemetry;
+import woflo.petsplus.state.processing.AsyncWorkCoordinator;
+import woflo.petsplus.state.processing.OwnerBatchSnapshot;
+import woflo.petsplus.state.processing.OwnerEventDispatcher;
+import woflo.petsplus.state.processing.OwnerEventFrame;
+import woflo.petsplus.state.processing.OwnerEventType;
+import woflo.petsplus.state.processing.OwnerProcessingManager;
+import woflo.petsplus.state.processing.OwnerTaskBatch;
+import woflo.petsplus.state.processing.OwnerSpatialResult;
+import woflo.petsplus.state.processing.OwnerSchedulingPrediction;
+import woflo.petsplus.events.XpEventHandler;
+import woflo.petsplus.state.gossip.GossipTopics;
+import woflo.petsplus.state.gossip.PetGossipLedger;
+import woflo.petsplus.state.gossip.RumorEntry;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * Manages state for all pets and owners in the game using components for persistence.
@@ -38,21 +68,71 @@ public class StateManager {
     private static final long SUPPORT_POTION_IDLE_RECHECK = 40L;
     private static final long PARTICLE_RECHECK_INTERVAL = 20L;
     private static final long DEFAULT_AURA_RECHECK = 40L;
+    private static final int MAX_SPATIAL_DEFERRALS = 3;
+    private static final long MAX_SPATIAL_WAIT_TICKS = 20L;
     
     private final ServerWorld world;
     private final Map<MobEntity, PetComponent> petComponents = new WeakHashMap<>();
     private final Map<PlayerEntity, OwnerCombatState> ownerStates = new WeakHashMap<>();
     private long nextMaintenanceTick;
+    private long lastTelemetryLogTick;
     private final PetSwarmIndex swarmIndex = new PetSwarmIndex();
     private final AuraTargetResolver auraTargetResolver = new AuraTargetResolver(swarmIndex);
     private final PetWorkScheduler workScheduler = new PetWorkScheduler();
-    
+    private final OwnerProcessingManager ownerProcessingManager = new OwnerProcessingManager();
+    private final OwnerBatchProcessor ownerBatchProcessor = new OwnerBatchProcessor();
+    private final OwnerEventDispatcher ownerEventDispatcher = new OwnerEventDispatcher();
+    private final AdaptiveTickScaler adaptiveTickScaler = new AdaptiveTickScaler();
+    private final AsyncWorkCoordinator asyncWorkCoordinator;
+    private final OwnerEventDispatcher.PresenceListener ownerPresenceListener;
+    private final EmotionStimulusBus.QueueListener stimulusQueueListener;
+    private final EmotionStimulusBus.IdleListener stimulusIdleListener;
+    private final Map<UUID, EnumMap<OwnerEventType, OwnerSpatialResult>> pendingSpatialResults = new HashMap<>();
+    private final Map<UUID, EnumMap<OwnerEventType, SpatialJobState>> spatialJobStates = new HashMap<>();
+    private boolean disposed;
+
     private StateManager(ServerWorld world) {
         this.world = world;
+        MinecraftServer server = world.getServer();
+        if (server == null) {
+            throw new IllegalStateException("Server world is missing server reference");
+        }
+        this.asyncWorkCoordinator = new AsyncWorkCoordinator(server, adaptiveTickScaler::loadFactor);
+        this.ownerPresenceListener = ownerProcessingManager::onListenerPresenceChanged;
+        this.stimulusQueueListener = this::handleStimulusQueued;
+        this.stimulusIdleListener = this::handleStimulusIdleScheduled;
+        registerOwnerEventListeners();
+        registerEmotionStimulusBridge();
     }
     
     public static StateManager forWorld(ServerWorld world) {
-        return WORLD_MANAGERS.computeIfAbsent(world, StateManager::new);
+        synchronized (WORLD_MANAGERS) {
+            return WORLD_MANAGERS.computeIfAbsent(world, StateManager::new);
+        }
+    }
+
+    public static void unloadWorld(ServerWorld world) {
+        if (world == null) {
+            return;
+        }
+        StateManager manager;
+        synchronized (WORLD_MANAGERS) {
+            manager = WORLD_MANAGERS.remove(world);
+        }
+        if (manager != null) {
+            manager.shutdown();
+        }
+    }
+
+    public static void unloadAll() {
+        java.util.List<StateManager> managers;
+        synchronized (WORLD_MANAGERS) {
+            managers = new java.util.ArrayList<>(WORLD_MANAGERS.values());
+            WORLD_MANAGERS.clear();
+        }
+        for (StateManager manager : managers) {
+            manager.shutdown();
+        }
     }
     
     public PetComponent getPetComponent(MobEntity pet) {
@@ -76,6 +156,7 @@ public class StateManager {
 
         component.ensureSpeciesDescriptorInitialized();
         swarmIndex.trackPet(pet, component);
+        ownerProcessingManager.trackPet(component);
         return component;
     }
 
@@ -168,6 +249,8 @@ public class StateManager {
         if (component != null) {
             workScheduler.unscheduleAll(component);
             component.markSchedulingUninitialized();
+            ownerProcessingManager.onTasksCleared(component);
+            ownerProcessingManager.untrackPet(component);
         }
         if (world instanceof ServerWorld) {
             MoodService.getInstance().untrackPet(pet);
@@ -180,6 +263,7 @@ public class StateManager {
         UUID ownerId = owner.getUuid();
         swarmIndex.removeOwner(ownerId);
         auraTargetResolver.handleOwnerRemoval(ownerId);
+        ownerProcessingManager.removeOwner(ownerId);
     }
 
     public void handleOwnerTick(ServerPlayerEntity player) {
@@ -188,6 +272,8 @@ public class StateManager {
         if (state != null) {
             state.tick();
         }
+
+        ownerProcessingManager.processOwnerTick(player, world.getTime());
 
         MinecraftServer server = player.getServer();
         if (server == null) {
@@ -236,19 +322,743 @@ public class StateManager {
 
         long time = world.getTime();
         component.ensureSchedulingInitialized(time);
-        component.updateSwarmTrackingIfMoved(swarmIndex);
+        boolean swarmUpdated = component.updateSwarmTrackingIfMoved(swarmIndex);
+        ownerProcessingManager.markPetChanged(component, time);
+        if (swarmUpdated) {
+            if (hasOwnerEventListeners(OwnerEventType.AURA)) {
+                ownerProcessingManager.signalEvent(component, OwnerEventType.AURA, time);
+            }
+            if (hasOwnerEventListeners(OwnerEventType.SUPPORT)) {
+                ownerProcessingManager.signalEvent(component, OwnerEventType.SUPPORT, time);
+            }
+            if (hasOwnerEventListeners(OwnerEventType.MOVEMENT)) {
+                ownerProcessingManager.signalEvent(component, OwnerEventType.MOVEMENT, time);
+            }
+        }
     }
 
     public void schedulePetTask(PetComponent component, PetWorkScheduler.TaskType type, long tick) {
         workScheduler.schedule(component, type, tick);
+        ownerProcessingManager.onTaskScheduled(component, type, tick);
     }
 
     public void unscheduleAllTasks(PetComponent component) {
         workScheduler.unscheduleAll(component);
+        ownerProcessingManager.onTasksCleared(component);
     }
 
     public void processScheduledPetTasks(long currentTick) {
-        workScheduler.processDue(currentTick, task -> runScheduledTask(task, currentTick));
+        asyncWorkCoordinator.drainMainThreadTasks();
+        adaptiveTickScaler.recordTick();
+        ownerProcessingManager.prepareForTick(currentTick);
+        workScheduler.processDue(currentTick, ownerProcessingManager::enqueueTask);
+        int pendingGroups = ownerProcessingManager.preparePendingGroups(currentTick);
+        int budget = adaptiveTickScaler.ownerBatchBudget(pendingGroups);
+        ownerProcessingManager.flushBatches((ownerId, batch) ->
+            ownerBatchProcessor.processBatch(batch, currentTick)
+        , currentTick, budget);
+        maybeLogAsyncTelemetry(currentTick);
+    }
+
+    public long scaleInterval(long baseTicks) {
+        if (baseTicks == Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        return adaptiveTickScaler.scaleInterval(baseTicks);
+    }
+
+    public AsyncWorkCoordinator asyncWorkCoordinator() {
+        return asyncWorkCoordinator;
+    }
+
+    private void maybeLogAsyncTelemetry(long currentTick) {
+        int interval = AsyncProcessingSettings.telemetryLogIntervalTicks();
+        if (interval <= 0) {
+            return;
+        }
+        if (currentTick - lastTelemetryLogTick < interval) {
+            return;
+        }
+        lastTelemetryLogTick = currentTick;
+        AsyncProcessingTelemetry telemetry = asyncWorkCoordinator.telemetry();
+        AsyncProcessingTelemetry.TelemetrySnapshot snapshot = telemetry.snapshotAndReset();
+        if (!snapshot.hasSamples()) {
+            return;
+        }
+        Petsplus.LOGGER.info("Async owner pipeline telemetry: {}", snapshot.toSummaryString());
+    }
+
+    private long scaleIntervalForDistance(long baseTicks, MobEntity pet, @Nullable ServerPlayerEntity owner) {
+        if (baseTicks <= 0L) {
+            return 1L;
+        }
+        if (baseTicks == Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+
+        long scaled = scaleInterval(baseTicks);
+        double factor = distanceQualityFactor(pet, owner);
+        if (factor <= 1.0D) {
+            return scaled;
+        }
+        long adjusted = Math.round(scaled * factor);
+        if (adjusted <= 0L) {
+            return 1L;
+        }
+        if (adjusted >= Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        return adjusted;
+    }
+
+    private double distanceQualityFactor(@Nullable MobEntity pet, @Nullable ServerPlayerEntity owner) {
+        if (pet == null || owner == null) {
+            return 1.0D;
+        }
+        double distanceSq = owner.squaredDistanceTo(pet);
+        if (distanceSq <= 32.0D * 32.0D) {
+            return 1.0D;
+        }
+        if (distanceSq <= 64.0D * 64.0D) {
+            return 1.5D;
+        }
+        if (distanceSq <= 96.0D * 96.0D) {
+            return 2.0D;
+        }
+        return 3.0D;
+    }
+
+    private boolean prepareSpatialPayload(OwnerBatchContext context,
+                                          OwnerEventType eventType,
+                                          long currentTick) {
+        if (!AsyncProcessingSettings.asyncSpatialAnalyticsEnabled()) {
+            return true;
+        }
+        UUID ownerId = context.batch().ownerId();
+        if (ownerId == null) {
+            return true;
+        }
+
+        OwnerSpatialResult cached = consumeSpatialResult(ownerId, eventType);
+        if (cached != null) {
+            context.attachPayload(eventType, cached);
+            clearSpatialJobState(ownerId, eventType);
+            return true;
+        }
+
+        SpatialJobState state = spatialJobState(ownerId, eventType);
+        if (state.pending) {
+            if (currentTick - state.lastRequestedTick > MAX_SPATIAL_WAIT_TICKS) {
+                state.markFailed();
+                return true;
+            }
+            return false;
+        }
+
+        if (state.attempts >= MAX_SPATIAL_DEFERRALS) {
+            return true;
+        }
+
+        state.markRequested(currentTick);
+        OwnerBatchSnapshot snapshot = context.snapshot();
+        asyncWorkCoordinator.submitOwnerBatch(
+            snapshot,
+            OwnerSpatialResult::analyze,
+            result -> storeSpatialResult(ownerId, eventType, result)
+        ).exceptionally(error -> {
+            Throwable cause = unwrapAsyncError(error);
+            if (cause instanceof RejectedExecutionException) {
+                Petsplus.LOGGER.debug("Async spatial analysis rejected for owner {}", ownerId);
+            } else {
+                Petsplus.LOGGER.error("Async spatial analysis failed for owner {}", ownerId, cause);
+            }
+            markSpatialJobFailed(ownerId, eventType);
+            return null;
+        });
+        return false;
+    }
+
+    private void storeSpatialResult(UUID ownerId,
+                                    OwnerEventType type,
+                                    OwnerSpatialResult result) {
+        if (ownerId == null || type == null || result == null) {
+            return;
+        }
+        pendingSpatialResults
+            .computeIfAbsent(ownerId, ignored -> new EnumMap<>(OwnerEventType.class))
+            .put(type, result);
+        spatialJobState(ownerId, type).markCompleted();
+    }
+
+    @Nullable
+    private OwnerSpatialResult consumeSpatialResult(UUID ownerId, OwnerEventType type) {
+        if (ownerId == null || type == null) {
+            return null;
+        }
+        EnumMap<OwnerEventType, OwnerSpatialResult> ownerResults = pendingSpatialResults.get(ownerId);
+        if (ownerResults == null) {
+            return null;
+        }
+        OwnerSpatialResult result = ownerResults.remove(type);
+        if (ownerResults.isEmpty()) {
+            pendingSpatialResults.remove(ownerId);
+        }
+        return result;
+    }
+
+    private void markSpatialJobFailed(UUID ownerId, OwnerEventType type) {
+        if (ownerId == null || type == null) {
+            return;
+        }
+        spatialJobState(ownerId, type).markFailed();
+    }
+
+    private void clearSpatialJobState(UUID ownerId, OwnerEventType type) {
+        if (ownerId == null || type == null) {
+            return;
+        }
+        EnumMap<OwnerEventType, SpatialJobState> states = spatialJobStates.get(ownerId);
+        if (states == null) {
+            return;
+        }
+        states.remove(type);
+        if (states.isEmpty()) {
+            spatialJobStates.remove(ownerId);
+        }
+    }
+
+    private SpatialJobState spatialJobState(UUID ownerId, OwnerEventType type) {
+        EnumMap<OwnerEventType, SpatialJobState> states = spatialJobStates.computeIfAbsent(
+            ownerId,
+            ignored -> new EnumMap<>(OwnerEventType.class)
+        );
+        return states.computeIfAbsent(type, ignored -> new SpatialJobState());
+    }
+
+    private static Throwable unwrapAsyncError(Throwable error) {
+        if (error instanceof CompletionException completion && completion.getCause() != null) {
+            return completion.getCause();
+        }
+        return error;
+    }
+
+    private void registerOwnerEventListeners() {
+        ownerEventDispatcher.addPresenceListener(ownerPresenceListener);
+        ownerEventDispatcher.register(OwnerEventType.INTERVAL, this::flushPendingMoodStimuli);
+        ownerEventDispatcher.register(OwnerEventType.XP_GAIN, XpEventHandler::handleOwnerXpGainEvent);
+        ownerEventDispatcher.register(OwnerEventType.GOSSIP, this::processGossipDecayEvent);
+        ownerEventDispatcher.register(OwnerEventType.SUPPORT, this::processSupportPotionEvent);
+        ownerEventDispatcher.register(OwnerEventType.ABILITY_TRIGGER, OwnerAbilityEventBridge.INSTANCE);
+    }
+
+    private boolean hasOwnerEventListeners(OwnerEventType type) {
+        return type != null && ownerEventDispatcher.hasListeners(type);
+    }
+
+    private void registerEmotionStimulusBridge() {
+        EmotionStimulusBus bus = MoodService.getInstance().getStimulusBus();
+        bus.addQueueListener(stimulusQueueListener);
+        bus.addIdleListener(stimulusIdleListener);
+    }
+
+    private void unregisterEmotionStimulusBridge() {
+        EmotionStimulusBus bus = MoodService.getInstance().getStimulusBus();
+        bus.removeQueueListener(stimulusQueueListener);
+        bus.removeIdleListener(stimulusIdleListener);
+    }
+
+    private void handleStimulusQueued(ServerWorld queuedWorld, MobEntity pet, long queuedTick) {
+        if (queuedWorld != this.world) {
+            return;
+        }
+        PetComponent component = getPetComponent(pet);
+        if (component.getOwnerUuid() == null) {
+            MoodService.getInstance().getStimulusBus().dispatchStimuli(pet);
+            return;
+        }
+
+        if (!hasOwnerEventListeners(OwnerEventType.INTERVAL)) {
+            MoodService.getInstance().getStimulusBus().dispatchStimuli(pet);
+            return;
+        }
+
+        long signalTick = Math.max(queuedTick, world.getTime());
+        ownerProcessingManager.signalEvent(component, OwnerEventType.INTERVAL, signalTick);
+    }
+
+    private boolean handleStimulusIdleScheduled(ServerWorld scheduledWorld, MobEntity pet, long scheduledTick) {
+        if (scheduledWorld != this.world) {
+            return false;
+        }
+        if (pet == null || pet.isRemoved()) {
+            return false;
+        }
+        PetComponent component = getPetComponent(pet);
+        if (component.getOwnerUuid() == null) {
+            return false;
+        }
+
+        if (!hasOwnerEventListeners(OwnerEventType.INTERVAL)) {
+            return false;
+        }
+
+        long signalTick = Math.max(scheduledTick, world.getTime() + 1L);
+        ownerProcessingManager.signalEvent(component, OwnerEventType.INTERVAL, signalTick);
+        return true;
+    }
+
+    private void flushPendingMoodStimuli(OwnerEventFrame frame) {
+        if (frame.pets().isEmpty()) {
+            return;
+        }
+
+        EmotionStimulusBus stimulusBus = MoodService.getInstance().getStimulusBus();
+        AsyncWorkCoordinator moodCoordinator = AsyncProcessingSettings.asyncMoodAnalyticsEnabled()
+            ? asyncWorkCoordinator
+            : null;
+        for (PetComponent component : frame.pets()) {
+            if (component == null) {
+                continue;
+            }
+            MobEntity pet = component.getPetEntity();
+            if (pet == null || pet.isRemoved()) {
+                continue;
+            }
+            stimulusBus.dispatchStimuli(pet, moodCoordinator);
+        }
+    }
+
+    private void processGossipDecayEvent(OwnerEventFrame frame) {
+        List<PetWorkScheduler.ScheduledTask> dueTasks = frame.batch().tasksFor(PetWorkScheduler.TaskType.GOSSIP_DECAY);
+        if (dueTasks.isEmpty()) {
+            return;
+        }
+
+        long currentTick = frame.currentTick();
+        List<PetSwarmIndex.SwarmEntry> swarmSnapshot = frame.swarmSnapshot();
+        if (swarmSnapshot.isEmpty()) {
+            UUID ownerId = frame.ownerId();
+            if (ownerId != null) {
+                swarmSnapshot = swarmIndex.snapshotOwner(ownerId);
+            }
+        }
+        if (swarmSnapshot.isEmpty()) {
+            return;
+        }
+
+        OwnerSpatialResult spatialResult = frame.payload(OwnerSpatialResult.class);
+        Map<UUID, PetSwarmIndex.SwarmEntry> swarmById = null;
+
+        for (PetWorkScheduler.ScheduledTask task : dueTasks) {
+            PetComponent component = task.component();
+            MobEntity pet = task.pet();
+            if (component == null || pet == null || pet.isRemoved()) {
+                continue;
+            }
+            if (component.isGossipOptedOut(currentTick)) {
+                continue;
+            }
+            component.attachStateManager(this);
+            PetGossipLedger ledger = component.getGossipLedger();
+            if (!ledger.hasShareableRumors(currentTick)) {
+                continue;
+            }
+            List<PetSwarmIndex.SwarmEntry> neighbors;
+            if (spatialResult != null) {
+                if (swarmById == null) {
+                    swarmById = new HashMap<>();
+                    for (PetSwarmIndex.SwarmEntry entry : swarmSnapshot) {
+                        MobEntity swarmPet = entry.pet();
+                        if (swarmPet != null) {
+                            swarmById.put(swarmPet.getUuid(), entry);
+                        }
+                    }
+                }
+                UUID storytellerId = pet.getUuid();
+                List<UUID> neighborIds = spatialResult.neighborsWithin(storytellerId, 12.0D, 4);
+                if (!neighborIds.isEmpty()) {
+                    neighbors = new ArrayList<>(neighborIds.size());
+                    for (UUID id : neighborIds) {
+                        PetSwarmIndex.SwarmEntry entry = swarmById.get(id);
+                        if (entry == null) {
+                            continue;
+                        }
+                        PetComponent neighborComponent = entry.component();
+                        if (neighborComponent == null || neighborComponent.isGossipOptedOut(currentTick)) {
+                            continue;
+                        }
+                        neighbors.add(entry);
+                        if (neighbors.size() >= 4) {
+                            break;
+                        }
+                    }
+                } else {
+                    neighbors = List.of();
+                }
+            } else {
+                neighbors = List.of();
+            }
+
+            if (neighbors.isEmpty()) {
+                neighbors = collectGossipNeighbors(pet, swarmSnapshot, currentTick);
+            }
+            if (neighbors.isEmpty()) {
+                continue;
+            }
+            shareRumorsWithNeighbors(component, neighbors, currentTick);
+        }
+    }
+
+    private void processSupportPotionEvent(OwnerEventFrame frame) {
+        List<PetWorkScheduler.ScheduledTask> dueTasks = frame.batch().tasksFor(PetWorkScheduler.TaskType.SUPPORT_POTION);
+        if (dueTasks.isEmpty()) {
+            return;
+        }
+
+        long currentTick = frame.currentTick();
+        ServerPlayerEntity frameOwner = frame.owner();
+
+        List<SupportScanRequest> requests = new ArrayList<>(dueTasks.size());
+        double sumX = 0.0D;
+        double sumY = 0.0D;
+        double sumZ = 0.0D;
+
+        for (PetWorkScheduler.ScheduledTask task : dueTasks) {
+            PetComponent component = task.component();
+            MobEntity pet = task.pet();
+            if (component == null || pet == null) {
+                continue;
+            }
+
+            PetComponent tracked = petComponents.get(pet);
+            if (tracked == null) {
+                continue;
+            }
+            if (tracked != component) {
+                cancelScheduledWork(component, pet);
+                continue;
+            }
+            if (!pet.isAlive()) {
+                cancelScheduledWork(component, pet);
+                continue;
+            }
+
+            ServerPlayerEntity owner = resolveSupportOwner(component, frameOwner);
+            if (owner == null) {
+                cancelScheduledWork(component, pet);
+                continue;
+            }
+
+            PetRoleType roleType = component.getRoleType(false);
+            if (roleType == null) {
+                component.scheduleNextSupportPotionScan(Long.MAX_VALUE);
+                ownerProcessingManager.onTaskExecuted(component, PetWorkScheduler.TaskType.SUPPORT_POTION, currentTick);
+                continue;
+            }
+
+            PetRoleType.SupportPotionBehavior behavior = roleType.supportPotionBehavior();
+            if (behavior == null) {
+                component.scheduleNextSupportPotionScan(Long.MAX_VALUE);
+                ownerProcessingManager.onTaskExecuted(component, PetWorkScheduler.TaskType.SUPPORT_POTION, currentTick);
+                continue;
+            }
+
+            component.attachStateManager(this);
+            component.ensureSchedulingInitialized(currentTick);
+
+            double radius = SupportPotionUtils.getAutoPickupRadius(component, behavior);
+            requests.add(new SupportScanRequest(pet, component, owner, behavior, radius));
+            sumX += pet.getX();
+            sumY += pet.getY();
+            sumZ += pet.getZ();
+        }
+
+        if (requests.isEmpty()) {
+            return;
+        }
+
+        int requestCount = requests.size();
+        double centerX = sumX / requestCount;
+        double centerY = sumY / requestCount;
+        double centerZ = sumZ / requestCount;
+
+        double maxReach = 0.0D;
+        double maxRadius = 0.0D;
+        for (SupportScanRequest request : requests) {
+            double dx = request.pet().getX() - centerX;
+            double dy = request.pet().getY() - centerY;
+            double dz = request.pet().getZ() - centerZ;
+            double distance = Math.sqrt((dx * dx) + (dy * dy) + (dz * dz));
+            double reach = distance + request.radius();
+            if (reach > maxReach) {
+                maxReach = reach;
+            }
+            if (request.radius() > maxRadius) {
+                maxRadius = request.radius();
+            }
+        }
+        if (maxReach <= 0.0D) {
+            maxReach = maxRadius;
+        }
+
+        List<ItemEntity> pooled = SupportPotionVacuumManager.getInstance()
+            .collectPotionsNearby(world, new Vec3d(centerX, centerY, centerZ), maxReach);
+        Set<ItemEntity> consumed = Collections.newSetFromMap(new IdentityHashMap<>());
+
+        for (SupportScanRequest request : requests) {
+            MobEntity pet = request.pet();
+            PetComponent component = request.component();
+            if (!pet.isAlive()) {
+                cancelScheduledWork(component, pet);
+                continue;
+            }
+
+            List<ItemEntity> available = new ArrayList<>();
+            for (ItemEntity item : pooled) {
+                if (!consumed.contains(item)) {
+                    available.add(item);
+                }
+            }
+
+            ItemEntity consumedItem = attemptSupportPotionPickup(
+                pet,
+                request.owner(),
+                component,
+                request.behavior(),
+                available,
+                request.radius()
+            );
+
+            long delayBase = consumedItem != null ? SUPPORT_POTION_ACTIVE_RECHECK : SUPPORT_POTION_IDLE_RECHECK;
+            long delay = scaleIntervalForDistance(delayBase, pet, request.owner());
+            component.scheduleNextSupportPotionScan(currentTick + delay);
+            ownerProcessingManager.onTaskExecuted(component, PetWorkScheduler.TaskType.SUPPORT_POTION, currentTick);
+
+            if (consumedItem != null) {
+                consumed.add(consumedItem);
+            }
+        }
+    }
+
+    @Nullable
+    private ServerPlayerEntity resolveSupportOwner(PetComponent component, @Nullable ServerPlayerEntity frameOwner) {
+        if (frameOwner != null && !frameOwner.isRemoved()) {
+            UUID overrideId = frameOwner.getUuid();
+            UUID componentOwnerId = component.getOwnerUuid();
+            if (componentOwnerId != null && componentOwnerId.equals(overrideId)) {
+                return frameOwner;
+            }
+        }
+
+        PlayerEntity owner = component.getOwner();
+        if (!(owner instanceof ServerPlayerEntity serverOwner) || owner.isRemoved()) {
+            return null;
+        }
+        return serverOwner;
+    }
+
+    private record SupportScanRequest(MobEntity pet,
+                                      PetComponent component,
+                                      ServerPlayerEntity owner,
+                                      PetRoleType.SupportPotionBehavior behavior,
+                                      double radius) {
+    }
+
+    private List<PetSwarmIndex.SwarmEntry> collectGossipNeighbors(MobEntity storyteller,
+                                                                  List<PetSwarmIndex.SwarmEntry> swarm,
+                                                                  long currentTick) {
+        if (storyteller == null) {
+            return List.of();
+        }
+        double originX = storyteller.getX();
+        double originY = storyteller.getY();
+        double originZ = storyteller.getZ();
+        double radius = 12.0;
+        double radiusSq = radius * radius;
+        List<PetSwarmIndex.SwarmEntry> matches = new ArrayList<>();
+        for (PetSwarmIndex.SwarmEntry entry : swarm) {
+            if (entry == null) {
+                continue;
+            }
+            if (entry.pet() == storyteller) {
+                continue;
+            }
+            PetComponent neighborComponent = entry.component();
+            if (neighborComponent == null || neighborComponent.isGossipOptedOut(currentTick)) {
+                continue;
+            }
+            double dx = entry.x() - originX;
+            double dy = entry.y() - originY;
+            double dz = entry.z() - originZ;
+            double distSq = (dx * dx) + (dy * dy) + (dz * dz);
+            if (distSq > radiusSq) {
+                continue;
+            }
+            matches.add(entry);
+        }
+        if (matches.isEmpty()) {
+            return List.of();
+        }
+        matches.sort((a, b) -> Double.compare(distanceSquared(a, originX, originY, originZ),
+            distanceSquared(b, originX, originY, originZ)));
+        int limit = Math.min(matches.size(), 4);
+        return new ArrayList<>(matches.subList(0, limit));
+    }
+
+    private double distanceSquared(PetSwarmIndex.SwarmEntry entry, double x, double y, double z) {
+        double dx = entry.x() - x;
+        double dy = entry.y() - y;
+        double dz = entry.z() - z;
+        return (dx * dx) + (dy * dy) + (dz * dz);
+    }
+
+    private void shareRumorsWithNeighbors(PetComponent storyteller,
+                                          List<PetSwarmIndex.SwarmEntry> neighbors,
+                                          long currentTick) {
+        if (neighbors.isEmpty()) {
+            return;
+        }
+        PetGossipLedger storytellerLedger = storyteller.getGossipLedger();
+        List<RumorEntry> freshRumors = storytellerLedger.peekFreshRumors(neighbors.size(), currentTick);
+        List<RumorEntry> rumors = freshRumors;
+        if (rumors.isEmpty()) {
+            rumors = storytellerLedger.peekAbstractRumors(Math.min(1, neighbors.size()), currentTick);
+        } else if (rumors.size() < neighbors.size()) {
+            List<RumorEntry> supplemental = storytellerLedger.peekAbstractRumors(neighbors.size() - rumors.size(), currentTick);
+            if (!supplemental.isEmpty()) {
+                rumors = new ArrayList<>(rumors);
+                rumors.addAll(supplemental);
+            }
+        }
+        if (rumors.isEmpty()) {
+            return;
+        }
+        Set<PetComponent> recipients = new HashSet<>();
+        int rumorIndex = 0;
+        for (PetSwarmIndex.SwarmEntry neighborEntry : neighbors) {
+            if (rumorIndex >= rumors.size()) {
+                break;
+            }
+            PetComponent neighborComponent = neighborEntry.component();
+            if (neighborComponent == null || !recipients.add(neighborComponent)) {
+                continue;
+            }
+            RumorEntry rumor = rumors.get(rumorIndex++);
+            PetGossipLedger neighborLedger = neighborComponent.getGossipLedger();
+            boolean alreadyHeard = neighborLedger.hasRumor(rumor.topicId());
+            neighborLedger.ingestRumorFromPeer(rumor, currentTick, alreadyHeard);
+            if (alreadyHeard) {
+                neighborLedger.registerDuplicateHeard(rumor.topicId(), currentTick);
+            } else if (GossipTopics.isAbstract(rumor.topicId())) {
+                neighborLedger.registerAbstractHeard(rumor.topicId(), currentTick);
+            }
+            storytellerLedger.markShared(rumor.topicId(), currentTick);
+        }
+    }
+
+    public OwnerEventDispatcher getOwnerEventDispatcher() {
+        return ownerEventDispatcher;
+    }
+
+    public void dispatchOwnerEvent(ServerPlayerEntity owner,
+                                   OwnerEventType eventType,
+                                   @Nullable Object payload) {
+        if (eventType == null) {
+            return;
+        }
+        EnumSet<OwnerEventType> events = EnumSet.of(eventType);
+        EnumMap<OwnerEventType, Object> payloads = null;
+        if (payload != null) {
+            payloads = new EnumMap<>(OwnerEventType.class);
+            payloads.put(eventType, payload);
+        }
+        dispatchOwnerEvents(owner, events, payloads);
+    }
+
+    public void dispatchOwnerEvents(@Nullable ServerPlayerEntity owner,
+                                    EnumSet<OwnerEventType> eventTypes,
+                                    @Nullable Map<OwnerEventType, Object> payloads) {
+        UUID ownerId = owner != null ? owner.getUuid() : null;
+        dispatchOwnerEvents(owner, ownerId, eventTypes, payloads);
+    }
+
+    public void dispatchOwnerEvents(@Nullable ServerPlayerEntity owner,
+                                    @Nullable UUID ownerId,
+                                    EnumSet<OwnerEventType> eventTypes,
+                                    @Nullable Map<OwnerEventType, Object> payloads) {
+        if ((owner == null || owner.isRemoved()) && ownerId == null) {
+            return;
+        }
+        if (eventTypes == null || eventTypes.isEmpty()) {
+            return;
+        }
+
+        EnumSet<OwnerEventType> interestedEvents = EnumSet.copyOf(eventTypes);
+        interestedEvents.removeIf(type -> type == null || !hasOwnerEventListeners(type));
+        if (interestedEvents.isEmpty()) {
+            return;
+        }
+
+        long currentTick = world.getTime();
+        UUID effectiveOwnerId = owner != null ? owner.getUuid() : ownerId;
+        ServerPlayerEntity sanitizedOwner = owner != null && !owner.isRemoved() ? owner : null;
+
+        EnumSet<OwnerEventType> immutableEvents = EnumSet.copyOf(interestedEvents);
+        EnumMap<OwnerEventType, Object> payloadCopy = null;
+        if (payloads != null && !payloads.isEmpty()) {
+            payloadCopy = new EnumMap<>(OwnerEventType.class);
+            for (Map.Entry<OwnerEventType, Object> entry : payloads.entrySet()) {
+                OwnerEventType type = entry.getKey();
+                Object value = entry.getValue();
+                if (type != null && value != null && immutableEvents.contains(type)) {
+                    payloadCopy.put(type, value);
+                }
+            }
+            if (payloadCopy.isEmpty()) {
+                payloadCopy = null;
+            }
+        }
+
+        OwnerTaskBatch batch = ownerProcessingManager.createAdHocBatch(effectiveOwnerId, immutableEvents, currentTick);
+        if (batch == null) {
+            List<PetSwarmIndex.SwarmEntry> swarmSnapshot = swarmIndex.snapshotOwner(effectiveOwnerId);
+            if (swarmSnapshot.isEmpty()) {
+                return;
+            }
+            List<PetComponent> pets = new ArrayList<>(swarmSnapshot.size());
+            for (PetSwarmIndex.SwarmEntry entry : swarmSnapshot) {
+                PetComponent component = entry.component();
+                if (component != null) {
+                    pets.add(component);
+                }
+            }
+            if (pets.isEmpty()) {
+                return;
+            }
+            batch = OwnerTaskBatch.adHoc(effectiveOwnerId, pets, immutableEvents, currentTick, sanitizedOwner);
+        }
+
+        try (OwnerTaskBatch closable = batch) {
+            ownerBatchProcessor.processBatch(closable, sanitizedOwner, currentTick, false, payloadCopy);
+        }
+    }
+
+    public void dispatchAbilityTrigger(ServerPlayerEntity owner,
+                                       String triggerId,
+                                       @Nullable Map<String, Object> eventData) {
+        if (owner == null || owner.isRemoved()) {
+            return;
+        }
+        if (triggerId == null || triggerId.isEmpty()) {
+            return;
+        }
+        if (!hasOwnerEventListeners(OwnerEventType.ABILITY_TRIGGER)) {
+            return;
+        }
+        EnumSet<OwnerEventType> events = EnumSet.of(OwnerEventType.ABILITY_TRIGGER);
+        EnumMap<OwnerEventType, Object> payload = new EnumMap<>(OwnerEventType.class);
+        payload.put(OwnerEventType.ABILITY_TRIGGER, AbilityTriggerPayload.of(triggerId, eventData));
+        dispatchOwnerEvents(owner, events, payload);
     }
 
     private void cancelScheduledWork(PetComponent component, MobEntity pet) {
@@ -256,9 +1066,24 @@ public class StateManager {
         component.markSchedulingUninitialized();
         component.invalidateSwarmTracking();
         swarmIndex.untrackPet(pet);
+        ownerProcessingManager.onTasksCleared(component);
+        ownerProcessingManager.untrackPet(component);
     }
 
     private void runScheduledTask(PetWorkScheduler.ScheduledTask task, long currentTick) {
+        runScheduledTask(task, null, null, currentTick);
+    }
+
+    private void runScheduledTask(PetWorkScheduler.ScheduledTask task,
+                                  @Nullable ServerPlayerEntity ownerOverride,
+                                  long currentTick) {
+        runScheduledTask(task, ownerOverride, null, currentTick);
+    }
+
+    private void runScheduledTask(PetWorkScheduler.ScheduledTask task,
+                                  @Nullable ServerPlayerEntity ownerOverride,
+                                  @Nullable OwnerBatchContext context,
+                                  long currentTick) {
         PetComponent component = task.component();
         MobEntity pet = task.pet();
         if (component == null || pet == null) {
@@ -280,8 +1105,25 @@ public class StateManager {
             return;
         }
 
-        PlayerEntity owner = component.getOwner();
-        if (!(owner instanceof ServerPlayerEntity serverOwner) || owner.isRemoved()) {
+        ServerPlayerEntity serverOwner = context != null ? context.owner() : null;
+        if (serverOwner == null && ownerOverride != null && !ownerOverride.isRemoved()) {
+            UUID overrideId = ownerOverride.getUuid();
+            UUID componentOwnerId = component.getOwnerUuid();
+            if (componentOwnerId != null && componentOwnerId.equals(overrideId)) {
+                serverOwner = ownerOverride;
+            }
+        }
+
+        if (serverOwner == null) {
+            PlayerEntity owner = component.getOwner();
+            if (!(owner instanceof ServerPlayerEntity resolvedOwner) || owner.isRemoved()) {
+                cancelScheduledWork(component, pet);
+                return;
+            }
+            serverOwner = resolvedOwner;
+        }
+
+        if (serverOwner.isRemoved()) {
             cancelScheduledWork(component, pet);
             return;
         }
@@ -290,21 +1132,25 @@ public class StateManager {
 
         switch (task.type()) {
             case INTERVAL -> runIntervalAbility(pet, component, serverOwner, currentTick);
-            case AURA -> runAuraPulse(pet, component, serverOwner, currentTick);
+            case AURA -> runAuraPulse(pet, component, serverOwner, context, currentTick);
             case SUPPORT_POTION -> runSupportScan(pet, component, serverOwner, currentTick);
-            case PARTICLE -> runParticlePass(pet, component, currentTick);
+            case PARTICLE -> runParticlePass(pet, component, serverOwner, currentTick);
             case GOSSIP_DECAY -> component.tickGossipLedger(currentTick);
         }
+
+        ownerProcessingManager.onTaskExecuted(component, task.type(), currentTick);
     }
 
     private void runIntervalAbility(MobEntity pet, PetComponent component, ServerPlayerEntity owner, long currentTick) {
         component.updateCooldowns();
         TriggerContext ctx = new TriggerContext(world, pet, owner, "interval_tick");
         woflo.petsplus.abilities.AbilityManager.triggerAbilities(pet, ctx);
-        component.scheduleNextIntervalTick(currentTick + INTERVAL_TICK_SPACING);
+        long delay = scaleIntervalForDistance(INTERVAL_TICK_SPACING, pet, owner);
+        component.scheduleNextIntervalTick(currentTick + delay);
     }
 
-    private void runAuraPulse(MobEntity pet, PetComponent component, ServerPlayerEntity owner, long currentTick) {
+    private void runAuraPulse(MobEntity pet, PetComponent component, ServerPlayerEntity owner,
+                              @Nullable OwnerBatchContext context, long currentTick) {
         PetRoleType roleType = component.getRoleType(false);
         if (roleType == null) {
             component.scheduleNextAuraCheck(Long.MAX_VALUE);
@@ -324,16 +1170,22 @@ public class StateManager {
                 component,
                 owner,
                 auraTargetResolver,
-                currentTick
+                currentTick,
+                context != null ? context.swarmSnapshot() : null
             );
+            long baseDelay;
             if (nextTick == Long.MAX_VALUE) {
-                component.scheduleNextAuraCheck(currentTick + DEFAULT_AURA_RECHECK);
+                baseDelay = DEFAULT_AURA_RECHECK;
             } else {
-                component.scheduleNextAuraCheck(Math.max(currentTick + 1, nextTick));
+                long scheduledTick = Math.max(currentTick + 1, nextTick);
+                baseDelay = Math.max(1L, scheduledTick - currentTick);
             }
+            long delay = scaleIntervalForDistance(baseDelay, pet, owner);
+            component.scheduleNextAuraCheck(currentTick + delay);
         } catch (Exception e) {
             Petsplus.LOGGER.warn("Failed to apply aura effects for pet {}", pet.getUuid(), e);
-            component.scheduleNextAuraCheck(currentTick + DEFAULT_AURA_RECHECK);
+            long delay = scaleIntervalForDistance(DEFAULT_AURA_RECHECK, pet, owner);
+            component.scheduleNextAuraCheck(currentTick + delay);
         }
     }
 
@@ -352,10 +1204,11 @@ public class StateManager {
 
         boolean processed = pickupNearbyPotionsForSupport(pet, owner, component, behavior);
         long delay = processed ? SUPPORT_POTION_ACTIVE_RECHECK : SUPPORT_POTION_IDLE_RECHECK;
+        delay = scaleIntervalForDistance(delay, pet, owner);
         component.scheduleNextSupportPotionScan(currentTick + delay);
     }
 
-    private void runParticlePass(MobEntity pet, PetComponent component, long currentTick) {
+    private void runParticlePass(MobEntity pet, PetComponent component, ServerPlayerEntity owner, long currentTick) {
         boolean emitted = false;
         if (woflo.petsplus.ui.ParticleEffectManager.shouldEmitParticles(pet, world)) {
             woflo.petsplus.ui.ParticleEffectManager.emitRoleParticles(pet, world, currentTick);
@@ -363,7 +1216,368 @@ public class StateManager {
         }
         component.updateCooldowns();
         long delay = emitted ? PARTICLE_RECHECK_INTERVAL : PARTICLE_RECHECK_INTERVAL * 2;
+        delay = scaleIntervalForDistance(delay, pet, owner);
         component.scheduleNextParticleCheck(currentTick + delay);
+    }
+
+    @Nullable
+    private ServerPlayerEntity resolveOnlineOwner(@Nullable UUID ownerId) {
+        if (ownerId == null) {
+            return null;
+        }
+        MinecraftServer server = world.getServer();
+        if (server == null) {
+            return null;
+        }
+        PlayerManager manager = server.getPlayerManager();
+        if (manager == null) {
+            return null;
+        }
+        ServerPlayerEntity player = manager.getPlayer(ownerId);
+        if (player == null || player.isRemoved()) {
+            return null;
+        }
+        return player;
+    }
+
+    private final class OwnerBatchProcessor {
+
+        void processBatch(OwnerTaskBatch batch, long currentTick) {
+            processBatch(batch, null, currentTick, true, null);
+        }
+
+        void processBatch(OwnerTaskBatch batch,
+                          @Nullable ServerPlayerEntity ownerOverride,
+                          long currentTick) {
+            processBatch(batch, ownerOverride, currentTick, true, null);
+        }
+
+        void processBatch(OwnerTaskBatch batch,
+                          @Nullable ServerPlayerEntity ownerOverride,
+                          long currentTick,
+                          boolean markEvents,
+                          @Nullable Map<OwnerEventType, Object> eventPayloads) {
+            if (batch == null || (batch.isEmpty() && batch.dueEventsView().isEmpty())) {
+                return;
+            }
+
+            ServerPlayerEntity owner = sanitizeOwner(ownerOverride);
+            if (owner == null) {
+                owner = sanitizeOwner(batch.lastKnownOwner());
+            }
+            if (owner == null) {
+                owner = resolveOnlineOwner(batch.ownerId());
+            }
+
+            long captureStart = System.nanoTime();
+            OwnerBatchSnapshot snapshot = OwnerBatchSnapshot.capture(batch);
+            asyncWorkCoordinator.telemetry().recordCaptureDuration(System.nanoTime() - captureStart);
+            OwnerBatchContext context = new OwnerBatchContext(batch, owner, eventPayloads, snapshot);
+
+            batch.forEachBucket((type, tasks) -> executeBucket(type, tasks, context, currentTick));
+            handleDueEvents(context, context.dueEvents(), currentTick, markEvents);
+            maybeSchedulePredictiveJob(context);
+        }
+
+        private ServerPlayerEntity sanitizeOwner(@Nullable ServerPlayerEntity candidate) {
+            if (candidate == null || candidate.isRemoved()) {
+                return null;
+            }
+            return candidate;
+        }
+
+        private void executeBucket(PetWorkScheduler.TaskType type,
+                                   List<PetWorkScheduler.ScheduledTask> tasks,
+                                   OwnerBatchContext context,
+                                   long currentTick) {
+            if (tasks == null || tasks.isEmpty()) {
+                return;
+            }
+
+            OwnerEventType eventType = OwnerEventType.fromTaskType(type);
+            boolean handledByEvent = eventType == OwnerEventType.SUPPORT
+                && context.dueEvents().contains(OwnerEventType.SUPPORT)
+                && ownerEventDispatcher.hasListeners(OwnerEventType.SUPPORT);
+
+            if (handledByEvent) {
+                return;
+            }
+
+            if (context.hasOwner()) {
+                switch (type) {
+                    case AURA, SUPPORT_POTION, GOSSIP_DECAY -> context.ensureSwarmSnapshot();
+                    case INTERVAL -> context.ensurePetsPrimed(currentTick);
+                    default -> {
+                    }
+                }
+            }
+
+            runTasks(tasks, context, currentTick);
+        }
+
+        private void runTasks(List<PetWorkScheduler.ScheduledTask> tasks,
+                              OwnerBatchContext context,
+                              long currentTick) {
+            ServerPlayerEntity owner = context.owner();
+            if (owner == null) {
+                for (PetWorkScheduler.ScheduledTask task : tasks) {
+                    StateManager.this.runScheduledTask(task, null, context, currentTick);
+                }
+                return;
+            }
+
+            for (PetWorkScheduler.ScheduledTask task : tasks) {
+                StateManager.this.runScheduledTask(task, owner, context, currentTick);
+            }
+        }
+
+        private void handleDueEvents(OwnerBatchContext context,
+                                     Set<OwnerEventType> dueEvents,
+                                     long currentTick,
+                                     boolean markEvents) {
+            if (dueEvents.isEmpty()) {
+                return;
+            }
+
+            EnumSet<OwnerEventType> activeEvents = EnumSet.noneOf(OwnerEventType.class);
+            for (OwnerEventType eventType : dueEvents) {
+                if (ownerEventDispatcher.hasListeners(eventType)) {
+                    activeEvents.add(eventType);
+                } else if (markEvents) {
+                    ownerProcessingManager.markOwnerEventExecuted(context.batch().ownerId(), eventType, currentTick);
+                }
+            }
+
+            if (activeEvents.isEmpty()) {
+                return;
+            }
+
+            EnumSet<OwnerEventType> deferred = context.prepareAsyncPayloads(activeEvents, currentTick);
+            if (!deferred.isEmpty()) {
+                UUID ownerId = context.batch().ownerId();
+                for (OwnerEventType type : deferred) {
+                    if (ownerId != null) {
+                        ownerProcessingManager.signalEvent(ownerId, type, currentTick + 1L);
+                    }
+                }
+                activeEvents.removeAll(deferred);
+            }
+
+            if (activeEvents.isEmpty()) {
+                return;
+            }
+
+            boolean requiresSwarm = false;
+            boolean primesScheduling = false;
+            for (OwnerEventType eventType : activeEvents) {
+                if (eventType.requiresSwarmSnapshot()) {
+                    requiresSwarm = true;
+                }
+                if (eventType.primesScheduling()) {
+                    primesScheduling = true;
+                }
+            }
+
+            if (requiresSwarm) {
+                context.ensureSwarmSnapshot();
+            }
+
+            if (primesScheduling) {
+                context.ensurePetsPrimed(currentTick);
+            }
+
+            dispatchOwnerEvents(context, activeEvents, currentTick, markEvents, requiresSwarm);
+        }
+
+        private void maybeSchedulePredictiveJob(OwnerBatchContext context) {
+            if (!AsyncProcessingSettings.asyncPredictiveSchedulingEnabled()) {
+                return;
+            }
+            OwnerBatchSnapshot snapshot = context.snapshot();
+            UUID ownerId = snapshot.ownerId();
+            if (ownerId == null) {
+                return;
+            }
+            asyncWorkCoordinator.submitOwnerBatch(
+                snapshot,
+                OwnerSchedulingPrediction::predict,
+                prediction -> {
+                    if (prediction == null || prediction.isEmpty()) {
+                        return;
+                    }
+                    ownerProcessingManager.applySchedulingPrediction(ownerId, prediction, world.getTime());
+                }
+            ).exceptionally(error -> {
+                Throwable cause = unwrapAsyncError(error);
+                if (cause instanceof RejectedExecutionException) {
+                    Petsplus.LOGGER.debug("Async predictive scheduling skipped for owner {} due to throttling", ownerId);
+                } else {
+                    Petsplus.LOGGER.error("Async predictive scheduling failed for owner {}", ownerId, cause);
+                }
+                return null;
+            });
+        }
+
+        private void dispatchOwnerEvents(OwnerBatchContext context,
+                                         EnumSet<OwnerEventType> dueEvents,
+                                         long currentTick,
+                                         boolean markEvents,
+                                         boolean requiresSwarmSnapshot) {
+            if (dueEvents.isEmpty()) {
+                return;
+            }
+
+            List<PetSwarmIndex.SwarmEntry> swarmSnapshot = requiresSwarmSnapshot
+                ? context.swarmSnapshot()
+                : context.swarmSnapshotIfPrimed();
+
+            for (OwnerEventType eventType : dueEvents) {
+                if (!ownerEventDispatcher.hasListeners(eventType)) {
+                    if (markEvents) {
+                        ownerProcessingManager.markOwnerEventExecuted(context.batch().ownerId(), eventType, currentTick);
+                    }
+                    continue;
+                }
+                try (OwnerEventFrame frame = OwnerEventFrame.obtain(
+                    eventType,
+                    world,
+                    context.owner(),
+                    context.batch().ownerId(),
+                    context.pets(),
+                    swarmSnapshot,
+                    dueEvents,
+                    currentTick,
+                    context.batch(),
+                    context.snapshot(),
+                    context.payload(eventType)
+                )) {
+                    ownerEventDispatcher.dispatch(frame);
+                }
+                if (markEvents) {
+                    ownerProcessingManager.markOwnerEventExecuted(context.batch().ownerId(), eventType, currentTick);
+                }
+            }
+        }
+    }
+
+    private final class OwnerBatchContext {
+        private final OwnerTaskBatch batch;
+        private final OwnerBatchSnapshot snapshot;
+        private final ServerPlayerEntity owner;
+        private final Set<OwnerEventType> dueEvents;
+        private final EnumMap<OwnerEventType, Object> payloads;
+        private List<PetSwarmIndex.SwarmEntry> swarmSnapshot = List.of();
+        private boolean swarmPrimed;
+
+        private OwnerBatchContext(OwnerTaskBatch batch,
+                                  @Nullable ServerPlayerEntity owner,
+                                  @Nullable Map<OwnerEventType, Object> eventPayloads,
+                                  OwnerBatchSnapshot snapshot) {
+            this.batch = batch;
+            this.snapshot = snapshot;
+            this.owner = owner != null && !owner.isRemoved() ? owner : null;
+            Set<OwnerEventType> events = batch.dueEventsView();
+            this.dueEvents = events.isEmpty()
+                ? Collections.emptySet()
+                : events;
+            if (eventPayloads == null || eventPayloads.isEmpty()) {
+                this.payloads = new EnumMap<>(OwnerEventType.class);
+            } else {
+                this.payloads = new EnumMap<>(OwnerEventType.class);
+                for (Map.Entry<OwnerEventType, Object> entry : eventPayloads.entrySet()) {
+                    OwnerEventType type = entry.getKey();
+                    Object value = entry.getValue();
+                    if (type != null && value != null) {
+                        this.payloads.put(type, value);
+                    }
+                }
+            }
+        }
+
+        EnumSet<OwnerEventType> prepareAsyncPayloads(EnumSet<OwnerEventType> candidates, long currentTick) {
+            if (candidates.isEmpty()) {
+                return EnumSet.noneOf(OwnerEventType.class);
+            }
+            EnumSet<OwnerEventType> deferred = EnumSet.noneOf(OwnerEventType.class);
+            for (OwnerEventType type : candidates) {
+                if (type == null || !type.requiresSwarmSnapshot()) {
+                    continue;
+                }
+                boolean ready = StateManager.this.prepareSpatialPayload(this, type, currentTick);
+                if (!ready) {
+                    deferred.add(type);
+                }
+            }
+            return deferred;
+        }
+
+        void attachPayload(OwnerEventType type, Object payload) {
+            if (type == null || payload == null) {
+                return;
+            }
+            payloads.put(type, payload);
+        }
+
+        OwnerBatchSnapshot snapshot() {
+            return snapshot;
+        }
+
+        Set<OwnerEventType> dueEvents() {
+            return dueEvents;
+        }
+
+        boolean hasOwner() {
+            return owner != null;
+        }
+
+        @Nullable
+        ServerPlayerEntity owner() {
+            return owner;
+        }
+
+        List<PetComponent> pets() {
+            return batch.pets();
+        }
+
+        OwnerTaskBatch batch() {
+            return batch;
+        }
+
+        void ensurePetsPrimed(long currentTick) {
+            for (PetComponent component : pets()) {
+                if (component != null) {
+                    component.ensureSchedulingInitialized(currentTick);
+                }
+            }
+        }
+
+        void ensureSwarmSnapshot() {
+            if (swarmPrimed) {
+                return;
+            }
+            UUID ownerId = batch.ownerId();
+            if (ownerId == null) {
+                swarmSnapshot = List.of();
+                swarmPrimed = true;
+                return;
+            }
+            swarmSnapshot = swarmIndex.snapshotOwner(ownerId);
+            swarmPrimed = true;
+        }
+
+        List<PetSwarmIndex.SwarmEntry> swarmSnapshot() {
+            ensureSwarmSnapshot();
+            return swarmSnapshot;
+        }
+
+        List<PetSwarmIndex.SwarmEntry> swarmSnapshotIfPrimed() {
+            return swarmPrimed ? swarmSnapshot : List.of();
+        }
+
+        @Nullable
+        Object payload(OwnerEventType type) {
+            return payloads.get(type);
+        }
     }
 
     /**
@@ -376,11 +1590,30 @@ public class StateManager {
         // This method is available for future enhancements or explicit saves
         int petCount = petComponents.size();
         int ownerCount = ownerStates.size();
-        
+
         if (petCount > 0 || ownerCount > 0) {
-            woflo.petsplus.Petsplus.LOGGER.debug("PetsPlus: Preparing to save world {} with {} pets and {} owners", 
+            woflo.petsplus.Petsplus.LOGGER.debug("PetsPlus: Preparing to save world {} with {} pets and {} owners",
                 world.getRegistryKey().getValue(), petCount, ownerCount);
         }
+    }
+
+    private void shutdown() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        unregisterEmotionStimulusBridge();
+        ownerEventDispatcher.removePresenceListener(ownerPresenceListener);
+        ownerEventDispatcher.clear();
+        workScheduler.clear();
+        ownerProcessingManager.shutdown();
+        swarmIndex.clear();
+        pendingSpatialResults.clear();
+        spatialJobStates.clear();
+        petComponents.clear();
+        ownerStates.clear();
+        asyncWorkCoordinator.drainMainThreadTasks();
+        asyncWorkCoordinator.close();
     }
     
     /**
@@ -405,24 +1638,59 @@ public class StateManager {
         return auraTargetResolver;
     }
 
+    public ServerWorld world() {
+        return world;
+    }
+
+    @Nullable
+    public ServerPlayerEntity findOnlineOwner(@Nullable UUID ownerId) {
+        return resolveOnlineOwner(ownerId);
+    }
+
     private boolean pickupNearbyPotionsForSupport(MobEntity pet, PlayerEntity owner, PetComponent component,
                                                   PetRoleType.SupportPotionBehavior behavior) {
-        if (!(world instanceof net.minecraft.server.world.ServerWorld serverWorld)) return false;
-        if (component.getLevel() < behavior.minLevel()) return false;
-
         double pickupRadius = SupportPotionUtils.getAutoPickupRadius(component, behavior);
-        List<net.minecraft.entity.ItemEntity> items = SupportPotionVacuumManager.getInstance()
+        List<ItemEntity> items = SupportPotionVacuumManager.getInstance()
             .collectPotionsNearby(pet, pickupRadius);
-        if (items.isEmpty()) return false;
+        return attemptSupportPotionPickup(pet, owner, component, behavior, items, pickupRadius) != null;
+    }
 
+    @Nullable
+    private ItemEntity attemptSupportPotionPickup(MobEntity pet,
+                                                  @Nullable PlayerEntity owner,
+                                                  PetComponent component,
+                                                  PetRoleType.SupportPotionBehavior behavior,
+                                                  Iterable<ItemEntity> candidates,
+                                                  double pickupRadius) {
+        if (pet == null || component == null || behavior == null) {
+            return null;
+        }
+        if (!pet.isAlive()) {
+            return null;
+        }
+        if (component.getLevel() < behavior.minLevel()) {
+            return null;
+        }
+        if (pickupRadius <= 0.0D) {
+            return null;
+        }
+
+        double radiusSq = pickupRadius * pickupRadius;
         var currentState = SupportPotionUtils.getStoredState(component);
 
-        boolean acceptedAny = false;
+        for (ItemEntity picked : candidates) {
+            if (picked == null || picked.isRemoved()) {
+                continue;
+            }
+            if (pet.squaredDistanceTo(picked) > radiusSq) {
+                continue;
+            }
 
-        for (net.minecraft.entity.ItemEntity picked : items) {
             var stack = picked.getStack();
             var incoming = SupportPotionUtils.createStateFromStack(stack, component);
-            if (!incoming.isValid()) continue;
+            if (!incoming.isValid()) {
+                continue;
+            }
 
             var outcome = SupportPotionUtils.mergePotionStates(
                 component,
@@ -451,7 +1719,6 @@ public class StateManager {
 
             SupportPotionUtils.writeStoredState(component, outcome.result());
             currentState = outcome.result();
-            acceptedAny = true;
 
             stack.decrement(1);
             SupportPotionVacuumManager.getInstance().handleStackChanged(picked);
@@ -460,6 +1727,7 @@ public class StateManager {
                 picked.discard();
             }
 
+            ServerWorld serverWorld = world;
             serverWorld.spawnParticles(net.minecraft.particle.ParticleTypes.HAPPY_VILLAGER,
                 pet.getX(), pet.getY() + pet.getHeight() * 0.5, pet.getZ(),
                 7, 0.25, 0.25, 0.25, 0.02);
@@ -486,9 +1754,109 @@ public class StateManager {
                 0.4f,
                 1.6f);
 
-            break;
+            return picked;
         }
-        return acceptedAny;
+
+        return null;
     }
 
+    private static final class SpatialJobState {
+        private int attempts;
+        private boolean pending;
+        private long lastRequestedTick;
+
+        void markRequested(long tick) {
+            attempts++;
+            pending = true;
+            lastRequestedTick = tick;
+        }
+
+        void markCompleted() {
+            pending = false;
+        }
+
+        void markFailed() {
+            pending = false;
+        }
+    }
+
+    private static final class AdaptiveTickScaler {
+        private static final long TARGET_TICK_NANOS = 50_000_000L;
+        private static final double SMOOTHING = 0.1D;
+        private static final double MIN_FACTOR = 0.5D;
+        private static final double MAX_FACTOR = 2.0D;
+
+        private long lastTickNanos;
+        private double emaTickNanos = TARGET_TICK_NANOS;
+        private boolean initialized;
+
+        void recordTick() {
+            long now = System.nanoTime();
+            if (!initialized) {
+                initialized = true;
+                lastTickNanos = now;
+                return;
+            }
+
+            long delta = now - lastTickNanos;
+            lastTickNanos = now;
+            if (delta <= 0L) {
+                return;
+            }
+
+            emaTickNanos = (SMOOTHING * delta) + ((1.0D - SMOOTHING) * emaTickNanos);
+        }
+
+        long scaleInterval(long baseTicks) {
+            if (baseTicks <= 0L) {
+                return 1L;
+            }
+            if (baseTicks >= Long.MAX_VALUE / 2L) {
+                return baseTicks;
+            }
+
+            double scaled = baseTicks * currentFactor();
+            long rounded = Math.round(scaled);
+            if (rounded <= 0L) {
+                return 1L;
+            }
+            if (rounded >= Long.MAX_VALUE) {
+                return Long.MAX_VALUE;
+            }
+            return rounded;
+        }
+
+        private double currentFactor() {
+            double factor = emaTickNanos / TARGET_TICK_NANOS;
+            if (factor < MIN_FACTOR) {
+                return MIN_FACTOR;
+            }
+            if (factor > MAX_FACTOR) {
+                return MAX_FACTOR;
+            }
+            return factor;
+        }
+
+        double loadFactor() {
+            return currentFactor();
+        }
+
+        int ownerBatchBudget(int pendingOwners) {
+            if (pendingOwners <= 0) {
+                return 0;
+            }
+
+            double factor = currentFactor();
+            double baseBudget = Math.min(Math.max(4.0D, pendingOwners), 32.0D);
+            double scaled = baseBudget / factor;
+            int budget = (int) Math.round(scaled);
+            if (budget < 1) {
+                budget = 1;
+            }
+            if (budget > pendingOwners) {
+                budget = pendingOwners;
+            }
+            return budget;
+        }
+    }
 }

--- a/src/main/java/woflo/petsplus/state/processing/AsyncProcessingSettings.java
+++ b/src/main/java/woflo/petsplus/state/processing/AsyncProcessingSettings.java
@@ -1,0 +1,74 @@
+package woflo.petsplus.state.processing;
+
+/**
+ * Simple feature flag holder for experimental asynchronous processing paths.
+ * Flags are read once at startup from system properties to avoid repeated
+ * string parsing on hot code paths.
+ */
+public final class AsyncProcessingSettings {
+    private static final boolean ENABLE_ASYNC_ABILITIES =
+        Boolean.parseBoolean(System.getProperty("petsplus.async.abilities", "false"));
+    private static final boolean SHADOW_ASYNC_ABILITIES =
+        Boolean.parseBoolean(System.getProperty("petsplus.async.abilities.shadow", "false"));
+    private static final boolean ENABLE_ASYNC_SPATIAL =
+        Boolean.parseBoolean(System.getProperty("petsplus.async.spatial", "false"));
+    private static final boolean ENABLE_ASYNC_PREDICTIVE =
+        Boolean.parseBoolean(System.getProperty("petsplus.async.predictive", "false"));
+    private static final boolean ENABLE_ASYNC_MOOD =
+        Boolean.parseBoolean(System.getProperty("petsplus.async.mood", "false"));
+    private static final int TELEMETRY_LOG_INTERVAL_TICKS = Math.max(
+        0,
+        Integer.parseInt(System.getProperty("petsplus.async.telemetry.interval", "0"))
+    );
+
+    private AsyncProcessingSettings() {
+    }
+
+    /**
+     * @return {@code true} when the asynchronous ability execution pipeline should
+     *         replace the synchronous path.
+     */
+    public static boolean asyncAbilitiesEnabled() {
+        return ENABLE_ASYNC_ABILITIES;
+    }
+
+    /**
+     * @return {@code true} when the asynchronous ability executor should run in
+     *         shadow mode (results are computed but not applied).
+     */
+    public static boolean asyncAbilitiesShadowEnabled() {
+        return SHADOW_ASYNC_ABILITIES;
+    }
+
+    /**
+     * @return {@code true} when spatial analytics should be prepared on the
+     *         background worker instead of during the main tick.
+     */
+    public static boolean asyncSpatialAnalyticsEnabled() {
+        return ENABLE_ASYNC_SPATIAL;
+    }
+
+    /**
+     * @return {@code true} when predictive scheduling should be computed on the
+     *         background worker.
+     */
+    public static boolean asyncPredictiveSchedulingEnabled() {
+        return ENABLE_ASYNC_PREDICTIVE;
+    }
+
+    /**
+     * @return {@code true} when queued emotion stimuli should be processed on the
+     *         background coordinator whenever possible.
+     */
+    public static boolean asyncMoodAnalyticsEnabled() {
+        return ENABLE_ASYNC_MOOD;
+    }
+
+    /**
+     * @return tick interval used to print async telemetry to the log, or {@code 0}
+     *         when telemetry logging is disabled.
+     */
+    public static int telemetryLogIntervalTicks() {
+        return TELEMETRY_LOG_INTERVAL_TICKS;
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/AsyncProcessingTelemetry.java
+++ b/src/main/java/woflo/petsplus/state/processing/AsyncProcessingTelemetry.java
@@ -1,0 +1,227 @@
+package woflo.petsplus.state.processing;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Simple metrics collector for the asynchronous owner-processing pipeline. The
+ * coordinator records capture, async execution, and main-thread application
+ * timings so operators can inspect the effectiveness of the decoupled stages.
+ */
+public final class AsyncProcessingTelemetry {
+    private final LongAdder captureNanos = new LongAdder();
+    private final LongAdder captureCount = new LongAdder();
+
+    private final LongAdder asyncNanos = new LongAdder();
+    private final LongAdder asyncCount = new LongAdder();
+
+    private final LongAdder applyNanos = new LongAdder();
+    private final LongAdder applyCount = new LongAdder();
+
+    private final AtomicInteger peakActiveJobs = new AtomicInteger();
+    private final AtomicInteger peakResultQueue = new AtomicInteger();
+    private final AtomicInteger peakDrainBatch = new AtomicInteger();
+    private final LongAdder throttledSubmissions = new LongAdder();
+    private final LongAdder rejectedSubmissions = new LongAdder();
+
+    private final AtomicLong lastSnapshotNanos = new AtomicLong(System.nanoTime());
+
+    public void recordCaptureDuration(long nanos) {
+        if (nanos <= 0L) {
+            return;
+        }
+        captureCount.increment();
+        captureNanos.add(nanos);
+    }
+
+    public void recordAsyncDuration(long nanos) {
+        if (nanos <= 0L) {
+            return;
+        }
+        asyncCount.increment();
+        asyncNanos.add(nanos);
+    }
+
+    public void recordApplyDuration(long nanos) {
+        if (nanos <= 0L) {
+            return;
+        }
+        applyCount.increment();
+        applyNanos.add(nanos);
+    }
+
+    public void recordActiveJobs(int activeJobs) {
+        updatePeak(peakActiveJobs, activeJobs);
+    }
+
+    public void recordResultQueueDepth(int queueDepth) {
+        updatePeak(peakResultQueue, queueDepth);
+    }
+
+    public void recordDrainBatchSize(int drained) {
+        updatePeak(peakDrainBatch, drained);
+    }
+
+    public void recordThrottledSubmission() {
+        throttledSubmissions.increment();
+    }
+
+    public void recordRejectedSubmission() {
+        rejectedSubmissions.increment();
+    }
+
+    public TelemetrySnapshot snapshotAndReset() {
+        long captureSamples = captureCount.sumThenReset();
+        long captureTotal = captureNanos.sumThenReset();
+        long asyncSamples = asyncCount.sumThenReset();
+        long asyncTotal = asyncNanos.sumThenReset();
+        long applySamples = applyCount.sumThenReset();
+        long applyTotal = applyNanos.sumThenReset();
+        long throttled = throttledSubmissions.sumThenReset();
+        long rejected = rejectedSubmissions.sumThenReset();
+
+        int peakJobs = peakActiveJobs.getAndSet(0);
+        int peakQueue = peakResultQueue.getAndSet(0);
+        int peakDrain = peakDrainBatch.getAndSet(0);
+
+        long now = System.nanoTime();
+        long interval = now - lastSnapshotNanos.getAndSet(now);
+
+        return new TelemetrySnapshot(
+            captureSamples,
+            captureTotal,
+            asyncSamples,
+            asyncTotal,
+            applySamples,
+            applyTotal,
+            peakJobs,
+            peakQueue,
+            peakDrain,
+            interval,
+            throttled,
+            rejected
+        );
+    }
+
+    private static void updatePeak(AtomicInteger target, int candidate) {
+        if (candidate <= 0) {
+            return;
+        }
+        int current;
+        do {
+            current = target.get();
+            if (candidate <= current) {
+                return;
+            }
+        } while (!target.compareAndSet(current, candidate));
+    }
+
+    /**
+     * Immutable view of the collected metrics during a sampling window.
+     */
+    public static final class TelemetrySnapshot {
+        private final long captureCount;
+        private final long captureNanos;
+        private final long asyncCount;
+        private final long asyncNanos;
+        private final long applyCount;
+        private final long applyNanos;
+        private final int peakActiveJobs;
+        private final int peakResultQueue;
+        private final int peakDrainBatch;
+        private final long windowNanos;
+        private final long throttledSubmissions;
+        private final long rejectedSubmissions;
+
+        private TelemetrySnapshot(long captureCount,
+                                  long captureNanos,
+                                  long asyncCount,
+                                  long asyncNanos,
+                                  long applyCount,
+                                  long applyNanos,
+                                  int peakActiveJobs,
+                                  int peakResultQueue,
+                                  int peakDrainBatch,
+                                  long windowNanos,
+                                  long throttledSubmissions,
+                                  long rejectedSubmissions) {
+            this.captureCount = captureCount;
+            this.captureNanos = captureNanos;
+            this.asyncCount = asyncCount;
+            this.asyncNanos = asyncNanos;
+            this.applyCount = applyCount;
+            this.applyNanos = applyNanos;
+            this.peakActiveJobs = peakActiveJobs;
+            this.peakResultQueue = peakResultQueue;
+            this.peakDrainBatch = peakDrainBatch;
+            this.windowNanos = windowNanos;
+            this.throttledSubmissions = throttledSubmissions;
+            this.rejectedSubmissions = rejectedSubmissions;
+        }
+
+        public boolean hasSamples() {
+            return captureCount > 0 || asyncCount > 0 || applyCount > 0
+                || throttledSubmissions > 0 || rejectedSubmissions > 0;
+        }
+
+        public double averageCaptureMillis() {
+            return averageMillis(captureNanos, captureCount);
+        }
+
+        public double averageAsyncMillis() {
+            return averageMillis(asyncNanos, asyncCount);
+        }
+
+        public double averageApplyMillis() {
+            return averageMillis(applyNanos, applyCount);
+        }
+
+        public int peakActiveJobs() {
+            return peakActiveJobs;
+        }
+
+        public int peakResultQueue() {
+            return peakResultQueue;
+        }
+
+        public int peakDrainBatch() {
+            return peakDrainBatch;
+        }
+
+        public long windowMillis() {
+            return Math.max(0L, windowNanos / 1_000_000L);
+        }
+
+        public long throttledSubmissions() {
+            return throttledSubmissions;
+        }
+
+        public long rejectedSubmissions() {
+            return rejectedSubmissions;
+        }
+
+        public String toSummaryString() {
+            return String.format(
+                "window=%dms captureAvg=%.3fms asyncAvg=%.3fms applyAvg=%.3fms peakJobs=%d peakQueue=%d peakDrain=%d throttled=%d rejected=%d",
+                windowMillis(),
+                averageCaptureMillis(),
+                averageAsyncMillis(),
+                averageApplyMillis(),
+                peakActiveJobs,
+                peakResultQueue,
+                peakDrainBatch,
+                throttledSubmissions,
+                rejectedSubmissions
+            );
+        }
+
+        private static double averageMillis(long totalNanos, long samples) {
+            if (samples <= 0 || totalNanos <= 0L) {
+                return 0.0D;
+            }
+            double nanosPerSample = (double) totalNanos / (double) samples;
+            return nanosPerSample / 1_000_000.0D;
+        }
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/AsyncWorkCoordinator.java
+++ b/src/main/java/woflo/petsplus/state/processing/AsyncWorkCoordinator.java
@@ -1,0 +1,372 @@
+package woflo.petsplus.state.processing;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.DoubleSupplier;
+
+import net.minecraft.server.MinecraftServer;
+
+import org.jetbrains.annotations.Nullable;
+
+import woflo.petsplus.Petsplus;
+
+import woflo.petsplus.state.processing.AsyncProcessingTelemetry;
+
+/**
+ * Coordinates background work for owner-centric processing. Jobs are executed on a
+ * bounded executor and their results are funneled back onto the main server thread
+ * via a double-buffered queue that can be drained deterministically each tick.
+ */
+public final class AsyncWorkCoordinator implements AutoCloseable {
+    private static final int MAX_IDLE_SECONDS = 30;
+    private static final AtomicLong THREAD_COUNTER = new AtomicLong();
+
+    private final DoubleSupplier loadFactorSupplier;
+    private final ExecutorService executor;
+    private final Executor mainThreadExecutor;
+    private final AtomicInteger activeJobs = new AtomicInteger();
+    private final AtomicBoolean drainScheduled = new AtomicBoolean();
+    private final ConcurrentLinkedQueue<Runnable>[] resultBuffers;
+    private final AtomicInteger[] bufferSizes;
+    private final AtomicInteger writeBufferIndex = new AtomicInteger();
+    private final int baseThreadCount;
+    private final AsyncProcessingTelemetry telemetry = new AsyncProcessingTelemetry();
+
+    public AsyncWorkCoordinator(MinecraftServer server,
+                                DoubleSupplier loadFactorSupplier) {
+        this(loadFactorSupplier, runnable -> Objects.requireNonNull(server, "server").submit(runnable));
+    }
+
+    @SuppressWarnings("unchecked")
+    AsyncWorkCoordinator(DoubleSupplier loadFactorSupplier, Executor mainThreadExecutor) {
+        this.loadFactorSupplier = loadFactorSupplier != null ? loadFactorSupplier : () -> 1.0D;
+        this.mainThreadExecutor = Objects.requireNonNull(mainThreadExecutor, "mainThreadExecutor");
+        int available = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+        this.baseThreadCount = Math.min(4, Math.max(1, available));
+        this.executor = createExecutor(this.baseThreadCount);
+        this.resultBuffers = new ConcurrentLinkedQueue[] {
+            new ConcurrentLinkedQueue<>(),
+            new ConcurrentLinkedQueue<>()
+        };
+        this.bufferSizes = new AtomicInteger[] {
+            new AtomicInteger(),
+            new AtomicInteger()
+        };
+    }
+
+    private ExecutorService createExecutor(int threads) {
+        ThreadFactory factory = runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("PetsPlus-Async-" + THREAD_COUNTER.incrementAndGet());
+            thread.setDaemon(true);
+            thread.setPriority(Thread.NORM_PRIORITY - 1);
+            return thread;
+        };
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+            threads,
+            threads,
+            MAX_IDLE_SECONDS,
+            TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            factory
+        );
+        pool.allowCoreThreadTimeOut(true);
+        return pool;
+    }
+
+    /**
+     * Submit an owner batch job for background execution.
+     *
+     * @param snapshot immutable owner batch description
+     * @param job asynchronous job to run
+     * @param applier synchronous consumer for the job result (executed on the main thread)
+     * @return future that completes once the synchronous applier finishes
+     */
+    public <T> CompletableFuture<T> submitOwnerBatch(OwnerBatchSnapshot snapshot,
+                                                     OwnerBatchJob<T> job,
+                                                     @Nullable Consumer<T> applier) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        Objects.requireNonNull(job, "job");
+
+        int allowedThreads = computeAllowedThreads();
+        if (allowedThreads <= 0) {
+            return rejectThrottled("Server TPS is too low for async work");
+        }
+
+        int maxJobs = computeMaxJobs(allowedThreads);
+        if (!tryAcquireSlot(maxJobs)) {
+            return rejectThrottled("Async job queue is at capacity");
+        }
+
+        telemetry.recordActiveJobs(activeJobs.get());
+        CompletableFuture<T> completion = new CompletableFuture<>();
+        try {
+            executor.execute(() -> runJob(snapshot, job, applier, completion));
+        } catch (RejectedExecutionException ex) {
+            activeJobs.decrementAndGet();
+            telemetry.recordActiveJobs(activeJobs.get());
+            telemetry.recordRejectedSubmission();
+            completion.completeExceptionally(ex);
+            return completion;
+        }
+        return completion;
+    }
+
+    /**
+     * Submit a non-owner-scoped task to the background executor while still
+     * respecting the coordinator's load-based throttling and main-thread
+     * application semantics.
+     */
+    public <T> CompletableFuture<T> submitStandalone(String descriptor,
+                                                     Callable<T> job,
+                                                     @Nullable Consumer<T> applier) {
+        Objects.requireNonNull(descriptor, "descriptor");
+        Objects.requireNonNull(job, "job");
+
+        int allowedThreads = computeAllowedThreads();
+        if (allowedThreads <= 0) {
+            return rejectThrottled("Standalone async task '" + descriptor + "' rejected: Server TPS is too low for async work");
+        }
+
+        int maxJobs = computeMaxJobs(allowedThreads);
+        if (!tryAcquireSlot(maxJobs)) {
+            return rejectThrottled("Standalone async task '" + descriptor + "' rejected: async job queue is at capacity");
+        }
+
+        telemetry.recordActiveJobs(activeJobs.get());
+        CompletableFuture<T> completion = new CompletableFuture<>();
+        try {
+            executor.execute(() -> runStandalone(descriptor, job, applier, completion));
+        } catch (RejectedExecutionException ex) {
+            activeJobs.decrementAndGet();
+            telemetry.recordActiveJobs(activeJobs.get());
+            telemetry.recordRejectedSubmission();
+            completion.completeExceptionally(ex);
+            return completion;
+        }
+        return completion;
+    }
+
+    private <T> void runJob(OwnerBatchSnapshot snapshot,
+                            OwnerBatchJob<T> job,
+                            @Nullable Consumer<T> applier,
+                            CompletableFuture<T> completion) {
+        long start = System.nanoTime();
+        T result = null;
+        Throwable failure = null;
+        try {
+            result = job.run(snapshot);
+        } catch (Throwable throwable) {
+            failure = throwable;
+        } finally {
+            telemetry.recordAsyncDuration(System.nanoTime() - start);
+        }
+
+        if (failure != null) {
+            Throwable finalFailure = failure;
+            enqueueResult(() -> {
+                long applyStart = System.nanoTime();
+                try {
+                    completion.completeExceptionally(finalFailure);
+                } finally {
+                    telemetry.recordApplyDuration(System.nanoTime() - applyStart);
+                }
+            });
+        } else {
+            T finalResult = result;
+            enqueueResult(() -> {
+                long applyStart = System.nanoTime();
+                try {
+                    if (applier != null) {
+                        applier.accept(finalResult);
+                    }
+                    completion.complete(finalResult);
+                } catch (Throwable applyError) {
+                    completion.completeExceptionally(applyError);
+                    throw applyError;
+                } finally {
+                    telemetry.recordApplyDuration(System.nanoTime() - applyStart);
+                }
+            });
+        }
+
+        activeJobs.decrementAndGet();
+        telemetry.recordActiveJobs(activeJobs.get());
+        scheduleDrain();
+    }
+
+    private <T> void runStandalone(String descriptor,
+                                   Callable<T> job,
+                                   @Nullable Consumer<T> applier,
+                                   CompletableFuture<T> completion) {
+        long start = System.nanoTime();
+        T result = null;
+        Throwable failure = null;
+        try {
+            result = job.call();
+        } catch (Throwable throwable) {
+            failure = throwable;
+        } finally {
+            telemetry.recordAsyncDuration(System.nanoTime() - start);
+        }
+
+        if (failure != null) {
+            Throwable finalFailure = failure;
+            enqueueResult(() -> {
+                long applyStart = System.nanoTime();
+                try {
+                    completion.completeExceptionally(finalFailure);
+                } finally {
+                    telemetry.recordApplyDuration(System.nanoTime() - applyStart);
+                }
+            });
+        } else {
+            T finalResult = result;
+            enqueueResult(() -> {
+                long applyStart = System.nanoTime();
+                try {
+                    if (applier != null) {
+                        applier.accept(finalResult);
+                    }
+                    completion.complete(finalResult);
+                } catch (Throwable applyError) {
+                    completion.completeExceptionally(applyError);
+                    throw applyError;
+                } finally {
+                    telemetry.recordApplyDuration(System.nanoTime() - applyStart);
+                }
+            });
+        }
+
+        activeJobs.decrementAndGet();
+        telemetry.recordActiveJobs(activeJobs.get());
+        scheduleDrain();
+    }
+
+    private void enqueueResult(Runnable runnable) {
+        int bufferIndex = writeBufferIndex.get();
+        ConcurrentLinkedQueue<Runnable> queue = resultBuffers[bufferIndex];
+        queue.add(runnable);
+        int depth = bufferSizes[bufferIndex].incrementAndGet();
+        telemetry.recordResultQueueDepth(depth);
+    }
+
+    private void scheduleDrain() {
+        if (drainScheduled.compareAndSet(false, true)) {
+            try {
+                mainThreadExecutor.execute(() -> {
+                    try {
+                        drainMainThreadTasks();
+                    } finally {
+                        drainScheduled.set(false);
+                    }
+                });
+            } catch (RejectedExecutionException ex) {
+                drainScheduled.set(false);
+                telemetry.recordRejectedSubmission();
+                Petsplus.LOGGER.warn("Failed to schedule async drain on main thread", ex);
+            }
+        }
+    }
+
+    /**
+     * Drain any queued main-thread callbacks. Should be invoked at the start of the
+     * server tick to preserve deterministic ordering with synchronous work.
+     *
+     * @return number of callbacks executed
+     */
+    public int drainMainThreadTasks() {
+        int bufferToDrain = writeBufferIndex.getAndUpdate(idx -> 1 - idx);
+        ConcurrentLinkedQueue<Runnable> queue = resultBuffers[bufferToDrain];
+        AtomicInteger bufferSize = bufferSizes[bufferToDrain];
+        int drained = 0;
+        Runnable task;
+        while ((task = queue.poll()) != null) {
+            try {
+                task.run();
+            } catch (Throwable throwable) {
+                Petsplus.LOGGER.error("Async result application failed", throwable);
+            }
+            drained++;
+        }
+        if (drained > 0) {
+            int remaining = bufferSize.addAndGet(-drained);
+            if (remaining < 0) {
+                bufferSize.set(0);
+            }
+        }
+        telemetry.recordDrainBatchSize(drained);
+        return drained;
+    }
+
+    private int computeAllowedThreads() {
+        double factor = loadFactorSupplier.getAsDouble();
+        if (factor >= 1.75D) {
+            return 0;
+        }
+        if (factor >= 1.35D) {
+            return Math.max(1, baseThreadCount / 2);
+        }
+        return baseThreadCount;
+    }
+
+    private int computeMaxJobs(int allowedThreads) {
+        if (allowedThreads <= 0) {
+            return 0;
+        }
+        return allowedThreads + Math.max(1, allowedThreads * 2);
+    }
+
+    private boolean tryAcquireSlot(int maxJobs) {
+        if (maxJobs <= 0) {
+            return false;
+        }
+        while (true) {
+            int current = activeJobs.get();
+            if (current >= maxJobs) {
+                return false;
+            }
+            if (activeJobs.compareAndSet(current, current + 1)) {
+                return true;
+            }
+        }
+    }
+
+    private <T> CompletableFuture<T> rejectThrottled(String message) {
+        telemetry.recordThrottledSubmission();
+        return rejectedFuture(message);
+    }
+
+    private static <T> CompletableFuture<T> rejectedFuture(String message) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        future.completeExceptionally(new RejectedExecutionException(message));
+        return future;
+    }
+
+    @Override
+    public void close() {
+        executor.shutdownNow();
+    }
+
+    public AsyncProcessingTelemetry telemetry() {
+        return telemetry;
+    }
+
+    @FunctionalInterface
+    public interface OwnerBatchJob<T> {
+        T run(OwnerBatchSnapshot snapshot) throws Exception;
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerBatchSnapshot.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerBatchSnapshot.java
@@ -1,0 +1,174 @@
+package woflo.petsplus.state.processing;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
+import org.jetbrains.annotations.Nullable;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetWorkScheduler;
+
+/**
+ * Immutable description of an owner task batch that strips out references to
+ * live world state so it can safely be handed to background workers.
+ */
+public final class OwnerBatchSnapshot {
+    private final UUID ownerId;
+    private final long snapshotTick;
+    private final UUID lastKnownOwnerId;
+    private final Set<OwnerEventType> dueEvents;
+    private final Map<PetWorkScheduler.TaskType, List<TaskSnapshot>> taskBuckets;
+    private final List<PetSummary> pets;
+
+    private OwnerBatchSnapshot(UUID ownerId,
+                               long snapshotTick,
+                               @Nullable UUID lastKnownOwnerId,
+                               Set<OwnerEventType> dueEvents,
+                               Map<PetWorkScheduler.TaskType, List<TaskSnapshot>> taskBuckets,
+                               List<PetSummary> pets) {
+        this.ownerId = ownerId;
+        this.snapshotTick = snapshotTick;
+        this.lastKnownOwnerId = lastKnownOwnerId;
+        this.dueEvents = dueEvents;
+        this.taskBuckets = taskBuckets;
+        this.pets = pets;
+    }
+
+    public UUID ownerId() {
+        return ownerId;
+    }
+
+    public long snapshotTick() {
+        return snapshotTick;
+    }
+
+    @Nullable
+    public UUID lastKnownOwnerId() {
+        return lastKnownOwnerId;
+    }
+
+    public Set<OwnerEventType> dueEvents() {
+        return dueEvents;
+    }
+
+    public Map<PetWorkScheduler.TaskType, List<TaskSnapshot>> taskBuckets() {
+        return taskBuckets;
+    }
+
+    public List<PetSummary> pets() {
+        return pets;
+    }
+
+    /**
+     * Create an immutable snapshot of the supplied batch for background execution.
+     */
+    public static OwnerBatchSnapshot capture(OwnerTaskBatch batch) {
+        Objects.requireNonNull(batch, "batch");
+        UUID ownerId = batch.ownerId();
+        long snapshotTick = batch.snapshotTick();
+        UUID lastKnownOwnerId = null;
+        ServerPlayerEntity lastKnownOwner = batch.lastKnownOwner();
+        if (lastKnownOwner != null) {
+            lastKnownOwnerId = lastKnownOwner.getUuid();
+        }
+
+        Set<OwnerEventType> dueEvents;
+        Set<OwnerEventType> dueView = batch.dueEventsView();
+        if (dueView.isEmpty()) {
+            dueEvents = Collections.emptySet();
+        } else {
+            dueEvents = Collections.unmodifiableSet(EnumSet.copyOf(dueView));
+        }
+
+        Map<PetWorkScheduler.TaskType, List<TaskSnapshot>> taskBuckets = new EnumMap<>(PetWorkScheduler.TaskType.class);
+        batch.forEachBucket((type, tasks) -> {
+            if (tasks == null || tasks.isEmpty()) {
+                return;
+            }
+            List<TaskSnapshot> sanitized = new ArrayList<>(tasks.size());
+            for (PetWorkScheduler.ScheduledTask task : tasks) {
+                PetComponent component = task.component();
+                Identifier roleId = component != null ? component.getRoleId() : null;
+                UUID petId = null;
+                if (component != null) {
+                    MobEntity entity = component.getPetEntity();
+                    petId = entity != null ? entity.getUuid() : null;
+                } else if (task.pet() != null) {
+                    petId = task.pet().getUuid();
+                }
+                sanitized.add(new TaskSnapshot(type, petId, roleId, task.dueTick()));
+            }
+            taskBuckets.put(type, List.copyOf(sanitized));
+        });
+
+        List<PetSummary> pets;
+        List<PetComponent> batchPets = batch.pets();
+        if (batchPets.isEmpty()) {
+            pets = List.of();
+        } else {
+            List<PetSummary> copies = new ArrayList<>(batchPets.size());
+            for (PetComponent component : batchPets) {
+                if (component == null) {
+                    continue;
+                }
+                MobEntity entity = component.getPetEntity();
+                UUID petId = entity != null ? entity.getUuid() : null;
+                Identifier roleId = component.getRoleId();
+                int level = component.getLevel();
+                long lastAttackTick = component.getLastAttackTick();
+                boolean perched = component.isPerched();
+                Map<String, Long> cooldowns = component.copyCooldownSnapshot();
+                Map<String, Long> sanitizedCooldowns = cooldowns.isEmpty()
+                    ? Map.of()
+                    : Collections.unmodifiableMap(cooldowns);
+                double x = Double.NaN;
+                double y = Double.NaN;
+                double z = Double.NaN;
+                if (entity != null) {
+                    x = entity.getX();
+                    y = entity.getY();
+                    z = entity.getZ();
+                }
+                copies.add(new PetSummary(petId, roleId, level, lastAttackTick, perched, x, y, z, sanitizedCooldowns));
+            }
+            pets = List.copyOf(copies);
+        }
+
+        return new OwnerBatchSnapshot(
+            ownerId,
+            snapshotTick,
+            lastKnownOwnerId,
+            dueEvents,
+            Collections.unmodifiableMap(taskBuckets),
+            pets
+        );
+    }
+
+    public record TaskSnapshot(PetWorkScheduler.TaskType type,
+                               @Nullable UUID petUuid,
+                               @Nullable Identifier roleId,
+                               long dueTick) {
+    }
+
+    public record PetSummary(UUID petUuid,
+                              @Nullable Identifier roleId,
+                              int level,
+                              long lastAttackTick,
+                              boolean perched,
+                              double x,
+                              double y,
+                              double z,
+                              Map<String, Long> cooldowns) {
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerEventDispatcher.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerEventDispatcher.java
@@ -1,0 +1,172 @@
+package woflo.petsplus.state.processing;
+
+import woflo.petsplus.Petsplus;
+
+/**
+ * Simple dispatcher for owner-scoped event listeners. Keeps listener registration
+ * lightweight so gameplay systems can opt into owner-centric batches instead of
+ * per-pet polling.
+ */
+public final class OwnerEventDispatcher {
+    private final java.util.EnumMap<OwnerEventType, ListenerBucket> listeners =
+        new java.util.EnumMap<>(OwnerEventType.class);
+    private final java.util.concurrent.CopyOnWriteArrayList<PresenceListener> presenceListeners =
+        new java.util.concurrent.CopyOnWriteArrayList<>();
+
+    public OwnerEventDispatcher() {
+        for (OwnerEventType type : OwnerEventType.values()) {
+            listeners.put(type, new ListenerBucket());
+        }
+    }
+
+    public void register(OwnerEventType type, OwnerEventListener listener) {
+        if (type == null || listener == null) {
+            return;
+        }
+        boolean becameActive = false;
+        synchronized (listeners) {
+            ListenerBucket bucket = listeners.computeIfAbsent(type, ignored -> new ListenerBucket());
+            becameActive = bucket.add(listener);
+        }
+        if (becameActive) {
+            notifyPresenceChanged(type, true);
+        }
+    }
+
+    public void unregister(OwnerEventType type, OwnerEventListener listener) {
+        if (type == null || listener == null) {
+            return;
+        }
+        boolean becameInactive = false;
+        synchronized (listeners) {
+            ListenerBucket bucket = listeners.get(type);
+            if (bucket != null) {
+                becameInactive = bucket.remove(listener);
+            }
+        }
+        if (becameInactive) {
+            notifyPresenceChanged(type, false);
+        }
+    }
+
+    public void dispatch(OwnerEventFrame frame) {
+        OwnerEventListener[] snapshot;
+        synchronized (listeners) {
+            ListenerBucket bucket = listeners.get(frame.eventType());
+            if (bucket == null || bucket.isEmpty()) {
+                return;
+            }
+            snapshot = bucket.snapshot();
+        }
+        for (OwnerEventListener listener : snapshot) {
+            try {
+                listener.onOwnerEvent(frame);
+            } catch (Exception ex) {
+                Petsplus.LOGGER.error("Owner event listener failed for event {}", frame.eventType(), ex);
+            }
+        }
+    }
+
+    public boolean hasListeners(OwnerEventType type) {
+        if (type == null) {
+            return false;
+        }
+        synchronized (listeners) {
+            ListenerBucket bucket = listeners.get(type);
+            return bucket != null && !bucket.isEmpty();
+        }
+    }
+
+    public void addPresenceListener(PresenceListener listener) {
+        if (listener == null) {
+            return;
+        }
+        java.util.EnumMap<OwnerEventType, Boolean> snapshot = new java.util.EnumMap<>(OwnerEventType.class);
+        synchronized (listeners) {
+            for (OwnerEventType type : OwnerEventType.values()) {
+                ListenerBucket bucket = listeners.get(type);
+                snapshot.put(type, bucket != null && !bucket.isEmpty());
+            }
+        }
+        presenceListeners.add(listener);
+        for (java.util.Map.Entry<OwnerEventType, Boolean> entry : snapshot.entrySet()) {
+            listener.onPresenceChanged(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public void removePresenceListener(PresenceListener listener) {
+        if (listener == null) {
+            return;
+        }
+        presenceListeners.remove(listener);
+    }
+
+    public void clear() {
+        synchronized (listeners) {
+            for (ListenerBucket bucket : listeners.values()) {
+                bucket.clear();
+            }
+        }
+        presenceListeners.clear();
+    }
+
+    private void notifyPresenceChanged(OwnerEventType type, boolean hasListeners) {
+        if (presenceListeners.isEmpty()) {
+            return;
+        }
+        for (PresenceListener listener : presenceListeners) {
+            try {
+                listener.onPresenceChanged(type, hasListeners);
+            } catch (Exception ex) {
+                Petsplus.LOGGER.error("Owner event presence listener failed for {}", type, ex);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface PresenceListener {
+        void onPresenceChanged(OwnerEventType type, boolean hasListeners);
+    }
+
+    private static final class ListenerBucket {
+        private final java.util.ArrayList<OwnerEventListener> listeners = new java.util.ArrayList<>();
+        private OwnerEventListener[] snapshot = new OwnerEventListener[0];
+        private boolean snapshotDirty = false;
+
+        boolean add(OwnerEventListener listener) {
+            if (listeners.contains(listener)) {
+                return false;
+            }
+            boolean wasEmpty = listeners.isEmpty();
+            listeners.add(listener);
+            snapshotDirty = true;
+            return wasEmpty;
+        }
+
+        boolean remove(OwnerEventListener listener) {
+            boolean removed = listeners.remove(listener);
+            if (removed) {
+                snapshotDirty = true;
+            }
+            return removed && listeners.isEmpty();
+        }
+
+        boolean isEmpty() {
+            return listeners.isEmpty();
+        }
+
+        OwnerEventListener[] snapshot() {
+            if (snapshotDirty) {
+                snapshot = listeners.toArray(OwnerEventListener[]::new);
+                snapshotDirty = false;
+            }
+            return snapshot;
+        }
+
+        void clear() {
+            listeners.clear();
+            snapshot = new OwnerEventListener[0];
+            snapshotDirty = false;
+        }
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerEventFrame.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerEventFrame.java
@@ -1,0 +1,186 @@
+package woflo.petsplus.state.processing;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+import org.jetbrains.annotations.Nullable;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetSwarmIndex;
+
+/**
+ * Snapshot describing an owner-scoped event dispatch. Provides batched context so
+ * listeners can respond without recalculating pet or spatial lookups. Instances are
+ * pooled; listeners must not retain a reference outside the dispatch callback.
+ */
+public final class OwnerEventFrame implements AutoCloseable {
+    private static final int MAX_POOL_SIZE = 256;
+
+    private static final java.util.ArrayDeque<OwnerEventFrame> POOL = new java.util.ArrayDeque<>();
+
+    private OwnerEventType eventType;
+    private ServerWorld world;
+    private @Nullable ServerPlayerEntity owner;
+    private @Nullable UUID ownerId;
+    private List<PetComponent> pets = List.of();
+    private List<PetSwarmIndex.SwarmEntry> swarmSnapshot = List.of();
+    private final EnumSet<OwnerEventType> dueEvents = EnumSet.noneOf(OwnerEventType.class);
+    private final Set<OwnerEventType> dueEventsView = Collections.unmodifiableSet(dueEvents);
+    private long currentTick;
+    private OwnerTaskBatch batch;
+    private OwnerBatchSnapshot snapshot;
+    private @Nullable Object payload;
+
+    private OwnerEventFrame() {
+    }
+
+    public static OwnerEventFrame obtain(OwnerEventType eventType,
+                                         ServerWorld world,
+                                         @Nullable ServerPlayerEntity owner,
+                                         @Nullable UUID ownerId,
+                                         List<PetComponent> pets,
+                                         List<PetSwarmIndex.SwarmEntry> swarmSnapshot,
+                                         EnumSet<OwnerEventType> dueEvents,
+                                         long currentTick,
+                                         OwnerTaskBatch batch,
+                                         OwnerBatchSnapshot snapshot,
+                                         @Nullable Object payload) {
+        OwnerEventFrame frame;
+        synchronized (POOL) {
+            frame = POOL.pollFirst();
+        }
+        if (frame == null) {
+            frame = new OwnerEventFrame();
+        }
+        frame.prepare(eventType, world, owner, ownerId, pets, swarmSnapshot, dueEvents, currentTick, batch, snapshot, payload);
+        return frame;
+    }
+
+    private void prepare(OwnerEventType eventType,
+                         ServerWorld world,
+                         @Nullable ServerPlayerEntity owner,
+                         @Nullable UUID ownerId,
+                         List<PetComponent> pets,
+                         List<PetSwarmIndex.SwarmEntry> swarmSnapshot,
+                         EnumSet<OwnerEventType> dueEvents,
+                         long currentTick,
+                         OwnerTaskBatch batch,
+                         OwnerBatchSnapshot snapshot,
+                         @Nullable Object payload) {
+        this.eventType = Objects.requireNonNull(eventType, "eventType");
+        this.world = Objects.requireNonNull(world, "world");
+        this.owner = owner;
+        this.ownerId = ownerId;
+        this.pets = pets == null || pets.isEmpty() ? List.of() : pets;
+        this.swarmSnapshot = swarmSnapshot == null || swarmSnapshot.isEmpty() ? List.of() : swarmSnapshot;
+        this.dueEvents.clear();
+        if (dueEvents != null && !dueEvents.isEmpty()) {
+            this.dueEvents.addAll(dueEvents);
+        }
+        this.currentTick = currentTick;
+        this.batch = Objects.requireNonNull(batch, "batch");
+        this.snapshot = Objects.requireNonNull(snapshot, "snapshot");
+        this.payload = payload;
+    }
+
+    private void reset() {
+        eventType = null;
+        world = null;
+        owner = null;
+        ownerId = null;
+        pets = List.of();
+        swarmSnapshot = List.of();
+        dueEvents.clear();
+        currentTick = 0L;
+        batch = null;
+        snapshot = null;
+        payload = null;
+    }
+
+    @Override
+    public void close() {
+        release();
+    }
+
+    public void release() {
+        reset();
+        synchronized (POOL) {
+            if (POOL.size() < MAX_POOL_SIZE) {
+                POOL.addFirst(this);
+            }
+        }
+    }
+
+    public OwnerEventType eventType() {
+        return eventType;
+    }
+
+    public ServerWorld world() {
+        return world;
+    }
+
+    @Nullable
+    public ServerPlayerEntity owner() {
+        return owner;
+    }
+
+    @Nullable
+    public UUID ownerId() {
+        return ownerId;
+    }
+
+    public List<PetComponent> pets() {
+        return pets;
+    }
+
+    public List<PetSwarmIndex.SwarmEntry> swarmSnapshot() {
+        return swarmSnapshot;
+    }
+
+    public Set<OwnerEventType> dueEvents() {
+        if (dueEvents.isEmpty()) {
+            return Set.of();
+        }
+        return dueEventsView;
+    }
+
+    public long currentTick() {
+        return currentTick;
+    }
+
+    public OwnerTaskBatch batch() {
+        return batch;
+    }
+
+    public OwnerBatchSnapshot snapshot() {
+        return snapshot;
+    }
+
+    @Nullable
+    public Object payload() {
+        return payload;
+    }
+
+    @Nullable
+    public <T> T payload(Class<T> type) {
+        if (type == null || payload == null) {
+            return null;
+        }
+        return type.isInstance(payload) ? type.cast(payload) : null;
+    }
+
+    public boolean hasOwner() {
+        return owner != null && !owner.isRemoved();
+    }
+
+    public boolean includesEvent(OwnerEventType type) {
+        return dueEvents.contains(type);
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerEventListener.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerEventListener.java
@@ -1,0 +1,6 @@
+package woflo.petsplus.state.processing;
+
+@FunctionalInterface
+public interface OwnerEventListener {
+    void onOwnerEvent(OwnerEventFrame frame);
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerEventType.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerEventType.java
@@ -1,0 +1,73 @@
+package woflo.petsplus.state.processing;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import woflo.petsplus.state.PetWorkScheduler;
+
+/**
+ * High level buckets that aggregate pet-centric upkeep work into owner-scoped
+ * events. These events are used by the {@link OwnerProcessingManager} to batch
+ * related work and drive event-triggered execution rather than polling.
+ */
+public enum OwnerEventType {
+    INTERVAL(PetWorkScheduler.TaskType.INTERVAL, false, true),
+    AURA(PetWorkScheduler.TaskType.AURA, true, false),
+    SUPPORT(PetWorkScheduler.TaskType.SUPPORT_POTION, true, false),
+    PARTICLE(PetWorkScheduler.TaskType.PARTICLE, false, false),
+    GOSSIP(PetWorkScheduler.TaskType.GOSSIP_DECAY, true, false),
+    MOVEMENT(null, true, false),
+    XP_GAIN(null, true, false),
+    ABILITY_TRIGGER(null, false, true);
+
+    private static final Map<PetWorkScheduler.TaskType, OwnerEventType> LOOKUP =
+        buildLookup();
+
+    private final PetWorkScheduler.TaskType schedulerType;
+    private final boolean requiresSwarmSnapshot;
+    private final boolean primesScheduling;
+
+    OwnerEventType(PetWorkScheduler.TaskType schedulerType,
+                   boolean requiresSwarmSnapshot,
+                   boolean primesScheduling) {
+        this.schedulerType = schedulerType;
+        this.requiresSwarmSnapshot = requiresSwarmSnapshot;
+        this.primesScheduling = primesScheduling;
+    }
+
+    public PetWorkScheduler.TaskType schedulerType() {
+        return schedulerType;
+    }
+
+    public boolean requiresSwarmSnapshot() {
+        return requiresSwarmSnapshot;
+    }
+
+    public boolean primesScheduling() {
+        return primesScheduling;
+    }
+
+    public static OwnerEventType fromTaskType(PetWorkScheduler.TaskType type) {
+        if (type == null) {
+            return null;
+        }
+        return LOOKUP.get(type);
+    }
+
+    private static Map<PetWorkScheduler.TaskType, OwnerEventType> buildLookup() {
+        EnumMap<PetWorkScheduler.TaskType, OwnerEventType> map =
+            new EnumMap<>(PetWorkScheduler.TaskType.class);
+        for (OwnerEventType eventType : values()) {
+            PetWorkScheduler.TaskType schedulerType = eventType.schedulerType;
+            if (schedulerType != null) {
+                map.put(Objects.requireNonNull(schedulerType), eventType);
+            }
+        }
+        return map;
+    }
+
+    public static EnumSet<OwnerEventType> noneOf() {
+        return EnumSet.noneOf(OwnerEventType.class);
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerEventWindow.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerEventWindow.java
@@ -1,0 +1,62 @@
+package woflo.petsplus.state.processing;
+
+/**
+ * Tracks the next scheduled execution tick for an owner-scoped event. The
+ * window remembers the earliest due tick and provides helpers for determining
+ * whether the event should be processed on the current tick.
+ */
+final class OwnerEventWindow {
+    private long nextTick = Long.MAX_VALUE;
+    private long lastRunTick = Long.MIN_VALUE;
+
+    void schedule(long tick) {
+        if (tick < 0L) {
+            tick = 0L;
+        }
+        if (tick <= lastRunTick) {
+            tick = lastRunTick + 1;
+        }
+        if (tick < nextTick) {
+            nextTick = tick;
+        }
+    }
+
+    void clear() {
+        nextTick = Long.MAX_VALUE;
+    }
+
+    void markRan(long tick) {
+        lastRunTick = tick;
+        nextTick = Long.MAX_VALUE;
+    }
+
+    boolean applyPrediction(long tick) {
+        if (tick < 0L) {
+            tick = 0L;
+        }
+        if (tick <= lastRunTick) {
+            tick = lastRunTick + 1L;
+        }
+        if (nextTick == tick) {
+            return false;
+        }
+        nextTick = tick;
+        return true;
+    }
+
+    boolean isDue(long currentTick) {
+        return currentTick >= nextTick;
+    }
+
+    boolean hasSchedule() {
+        return nextTick != Long.MAX_VALUE;
+    }
+
+    long nextTick() {
+        return nextTick;
+    }
+
+    long lastRunTick() {
+        return lastRunTick;
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerProcessingGroup.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerProcessingGroup.java
@@ -1,0 +1,365 @@
+package woflo.petsplus.state.processing;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.jetbrains.annotations.Nullable;
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetWorkScheduler;
+
+/**
+ * Represents the aggregation of all pet work associated with a single owner.
+ * The group caches pet lookups, batches scheduled tasks, and keeps track of
+ * owner-scoped events so that the dispatcher can process them in large chunks
+ * rather than per-pet polling.
+ */
+final class OwnerProcessingGroup {
+    private final UUID ownerId;
+    private final Map<MobEntity, PetComponent> petLookup = new IdentityHashMap<>();
+    private final EnumMap<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> pendingTasks =
+        new EnumMap<>(PetWorkScheduler.TaskType.class);
+    private final EnumMap<OwnerEventType, OwnerEventWindow> eventWindows =
+        new EnumMap<>(OwnerEventType.class);
+    private final EnumMap<OwnerEventType, Long> deferredEvents =
+        new EnumMap<>(OwnerEventType.class);
+
+    private final List<PetComponent> cachedPets = new ArrayList<>();
+    private List<PetComponent> cachedPetsView = List.of();
+    private boolean petCacheDirty = true;
+    private long lastPetRefreshTick = Long.MIN_VALUE;
+    private @Nullable ServerPlayerEntity lastKnownOwner;
+    private long nextEventTick = Long.MAX_VALUE;
+    private boolean pending;
+
+    OwnerProcessingGroup(UUID ownerId) {
+        this.ownerId = ownerId;
+    }
+
+    UUID ownerId() {
+        return ownerId;
+    }
+
+    void track(PetComponent component) {
+        MobEntity pet = component.getPetEntity();
+        if (pet == null) {
+            return;
+        }
+        petLookup.put(pet, component);
+        petCacheDirty = true;
+    }
+
+    void untrack(PetComponent component) {
+        MobEntity pet = component.getPetEntity();
+        if (pet == null) {
+            return;
+        }
+        if (petLookup.remove(pet) != null) {
+            petCacheDirty = true;
+        }
+    }
+
+    boolean isEmpty() {
+        return petLookup.isEmpty() && pendingTasks.isEmpty() && !hasScheduledEvents();
+    }
+
+    Collection<PetComponent> currentPets() {
+        return petLookup.values();
+    }
+
+    void clear() {
+        petLookup.clear();
+        cachedPets.clear();
+        cachedPetsView = List.of();
+        for (List<PetWorkScheduler.ScheduledTask> list : pendingTasks.values()) {
+            PooledTaskLists.recycle(list);
+        }
+        pendingTasks.clear();
+        eventWindows.clear();
+        deferredEvents.clear();
+        petCacheDirty = true;
+        lastKnownOwner = null;
+        lastPetRefreshTick = Long.MIN_VALUE;
+        nextEventTick = Long.MAX_VALUE;
+        pending = false;
+    }
+
+    void beginTick(long currentTick) {
+        if (currentTick - lastPetRefreshTick > 40L) {
+            petCacheDirty = true;
+        }
+    }
+
+    void markPetChanged(PetComponent component, long currentTick) {
+        track(component);
+        lastPetRefreshTick = currentTick;
+    }
+
+    void onOwnerTick(ServerPlayerEntity owner, long currentTick) {
+        this.lastKnownOwner = owner;
+        beginTick(currentTick);
+    }
+
+    void onTaskScheduled(PetComponent component,
+                         PetWorkScheduler.TaskType type,
+                         long tick,
+                         boolean eventEnabled) {
+        OwnerEventType eventType = OwnerEventType.fromTaskType(type);
+        if (eventType != null) {
+            if (eventEnabled) {
+                eventWindows.computeIfAbsent(eventType, ignored -> new OwnerEventWindow()).schedule(tick);
+                deferredEvents.remove(eventType);
+                recomputeNextEventTick();
+            } else {
+                deferEvent(eventType, tick);
+            }
+        }
+        markPetChanged(component, tick);
+    }
+
+    void onTaskExecuted(PetComponent component,
+                        PetWorkScheduler.TaskType type,
+                        long tick,
+                        boolean eventEnabled) {
+        OwnerEventType eventType = OwnerEventType.fromTaskType(type);
+        if (eventType != null) {
+            if (eventEnabled) {
+                OwnerEventWindow window = eventWindows.get(eventType);
+                if (window != null) {
+                    window.markRan(tick);
+                }
+                deferredEvents.remove(eventType);
+            } else {
+                deferEvent(eventType, tick);
+            }
+            recomputeNextEventTick();
+        }
+        markPetChanged(component, tick);
+    }
+
+    void onTasksCleared(PetComponent component) {
+        for (OwnerEventWindow window : eventWindows.values()) {
+            window.clear();
+        }
+        deferredEvents.clear();
+        markPetChanged(component, lastPetRefreshTick);
+        recomputeNextEventTick();
+    }
+
+    void enqueue(PetWorkScheduler.ScheduledTask task) {
+        List<PetWorkScheduler.ScheduledTask> list = pendingTasks.get(task.type());
+        if (list == null) {
+            list = PooledTaskLists.borrow();
+            pendingTasks.put(task.type(), list);
+        }
+        list.add(task);
+    }
+
+    boolean hasPendingTasks() {
+        for (List<PetWorkScheduler.ScheduledTask> list : pendingTasks.values()) {
+            if (list != null && !list.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean hasDueEvents(long currentTick) {
+        for (OwnerEventWindow window : eventWindows.values()) {
+            if (window != null && window.isDue(currentTick)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    OwnerTaskBatch drain(long currentTick) {
+        OwnerTaskBatch batch = OwnerTaskBatch.obtain(ownerId, currentTick, lastKnownOwner);
+        var iterator = pendingTasks.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> entry = iterator.next();
+            List<PetWorkScheduler.ScheduledTask> tasks = entry.getValue();
+            if (tasks == null || tasks.isEmpty()) {
+                if (tasks != null) {
+                    PooledTaskLists.recycle(tasks);
+                }
+                iterator.remove();
+                continue;
+            }
+            batch.addBucket(entry.getKey(), tasks);
+            iterator.remove();
+        }
+
+        EnumSet<OwnerEventType> dueEvents = EnumSet.noneOf(OwnerEventType.class);
+        for (Map.Entry<OwnerEventType, OwnerEventWindow> entry : eventWindows.entrySet()) {
+            OwnerEventWindow window = entry.getValue();
+            if (window != null && window.isDue(currentTick)) {
+                dueEvents.add(entry.getKey());
+            }
+        }
+
+        batch.attachDueEvents(dueEvents);
+        batch.attachPets(snapshotPets());
+        return batch;
+    }
+
+    private List<PetComponent> snapshotPets() {
+        if (petCacheDirty) {
+            cachedPets.clear();
+            cachedPets.addAll(petLookup.values());
+            cachedPetsView = cachedPets.isEmpty() ? List.of() : List.copyOf(cachedPets);
+            petCacheDirty = false;
+        }
+        return cachedPetsView;
+    }
+
+    @Nullable
+    ServerPlayerEntity lastKnownOwner() {
+        return lastKnownOwner;
+    }
+
+    void signalEvent(OwnerEventType type, long tick, boolean eventEnabled) {
+        if (type == null) {
+            return;
+        }
+        if (eventEnabled) {
+            OwnerEventWindow window = eventWindows.computeIfAbsent(type, ignored -> new OwnerEventWindow());
+            window.schedule(tick);
+            deferredEvents.remove(type);
+            recomputeNextEventTick();
+        } else {
+            deferEvent(type, tick);
+        }
+    }
+
+    void markEventExecuted(OwnerEventType type, long tick, boolean eventEnabled) {
+        if (type == null) {
+            return;
+        }
+        if (eventEnabled) {
+            OwnerEventWindow window = eventWindows.get(type);
+            if (window != null) {
+                window.markRan(tick);
+                if (!window.hasSchedule()) {
+                    eventWindows.remove(type);
+                }
+            }
+            deferredEvents.remove(type);
+        } else {
+            deferredEvents.remove(type);
+        }
+        recomputeNextEventTick();
+    }
+
+    OwnerTaskBatch snapshot(EnumSet<OwnerEventType> dueEvents, long currentTick) {
+        OwnerTaskBatch batch = OwnerTaskBatch.obtain(ownerId, currentTick, lastKnownOwner);
+        if (dueEvents != null && !dueEvents.isEmpty()) {
+            batch.attachDueEvents(EnumSet.copyOf(dueEvents));
+        }
+        batch.attachPets(snapshotPets());
+        return batch;
+    }
+
+    boolean applyPrediction(OwnerEventType type, long predictedTick) {
+        if (type == null) {
+            return false;
+        }
+        OwnerEventWindow window = eventWindows.computeIfAbsent(type, ignored -> new OwnerEventWindow());
+        boolean changed = window.applyPrediction(predictedTick);
+        if (changed) {
+            deferredEvents.remove(type);
+            recomputeNextEventTick();
+        }
+        return changed;
+    }
+
+    long nextEventTick() {
+        return nextEventTick;
+    }
+
+    boolean markPending() {
+        if (pending) {
+            return false;
+        }
+        pending = true;
+        return true;
+    }
+
+    void clearPendingFlag() {
+        pending = false;
+    }
+
+    boolean isPending() {
+        return pending;
+    }
+
+    private void recomputeNextEventTick() {
+        long candidate = Long.MAX_VALUE;
+        for (OwnerEventWindow window : eventWindows.values()) {
+            if (window == null) {
+                continue;
+            }
+            long next = window.nextTick();
+            if (next < candidate) {
+                candidate = next;
+            }
+        }
+        nextEventTick = candidate;
+    }
+
+    private boolean hasScheduledEvents() {
+        for (OwnerEventWindow window : eventWindows.values()) {
+            if (window != null && window.hasSchedule()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void deferEvent(OwnerEventType type, long tick) {
+        if (type == null) {
+            return;
+        }
+        long clamped = Math.max(0L, tick);
+        Long existing = deferredEvents.get(type);
+        if (existing == null || clamped < existing) {
+            deferredEvents.put(type, clamped);
+        }
+    }
+
+    boolean activateDeferredEvent(OwnerEventType type, long currentTick) {
+        if (type == null) {
+            return false;
+        }
+        Long deferred = deferredEvents.remove(type);
+        if (deferred == null) {
+            return false;
+        }
+        OwnerEventWindow window = eventWindows.computeIfAbsent(type, ignored -> new OwnerEventWindow());
+        long scheduledTick = Math.max(currentTick, deferred);
+        window.schedule(scheduledTick);
+        recomputeNextEventTick();
+        return true;
+    }
+
+    boolean deactivateEvent(OwnerEventType type) {
+        if (type == null) {
+            return false;
+        }
+        OwnerEventWindow window = eventWindows.remove(type);
+        if (window == null) {
+            return false;
+        }
+        if (window.hasSchedule()) {
+            deferEvent(type, window.nextTick());
+        }
+        recomputeNextEventTick();
+        return true;
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerProcessingManager.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerProcessingManager.java
@@ -1,0 +1,471 @@
+package woflo.petsplus.state.processing;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.jetbrains.annotations.Nullable;
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetWorkScheduler;
+
+/**
+ * Coordinates aggregation of pet upkeep tasks into owner-scoped batches. This
+ * manager keeps an owner cache that can be used by high-level systems to process
+ * swarms in a single pass and to pivot toward event-driven scheduling.
+ */
+public final class OwnerProcessingManager {
+    private static final EnumSet<OwnerEventType> ALWAYS_ACTIVE_EVENTS = EnumSet.of(OwnerEventType.INTERVAL);
+
+    private final Map<UUID, OwnerProcessingGroup> groups = new HashMap<>();
+    private final Map<PetComponent, UUID> membership = new IdentityHashMap<>();
+    private final List<PetWorkScheduler.ScheduledTask> orphanTasks = new ArrayList<>();
+    private final ArrayDeque<OwnerProcessingGroup> pendingQueue = new ArrayDeque<>();
+    private final TreeMap<Long, List<OwnerProcessingGroup>> eventDueQueue = new TreeMap<>();
+    private final EnumSet<OwnerEventType> activeEvents = EnumSet.copyOf(ALWAYS_ACTIVE_EVENTS);
+    private final EnumMap<OwnerEventType, Boolean> lastPresence = new EnumMap<>(OwnerEventType.class);
+    private long currentTick;
+
+    public void trackPet(PetComponent component) {
+        if (component == null) {
+            return;
+        }
+        UUID ownerId = component.getOwnerUuid();
+        UUID previous = membership.put(component, ownerId);
+        if (previous != null && (ownerId == null || !previous.equals(ownerId))) {
+            OwnerProcessingGroup previousGroup = groups.get(previous);
+            if (previousGroup != null) {
+                previousGroup.untrack(component);
+                if (previousGroup.isEmpty()) {
+                    groups.remove(previous);
+                }
+            }
+        }
+        if (ownerId == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.computeIfAbsent(ownerId, OwnerProcessingGroup::new);
+        group.track(component);
+    }
+
+    public void untrackPet(PetComponent component) {
+        if (component == null) {
+            return;
+        }
+        UUID ownerId = membership.remove(component);
+        if (ownerId == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.get(ownerId);
+        if (group != null) {
+            group.untrack(component);
+            if (group.isEmpty()) {
+                groups.remove(ownerId);
+            }
+        }
+    }
+
+    public void removeOwner(UUID ownerId) {
+        OwnerProcessingGroup group = groups.remove(ownerId);
+        if (group != null) {
+            for (PetComponent component : group.currentPets()) {
+                membership.remove(component);
+            }
+            group.clear();
+        }
+    }
+
+    public void markPetChanged(PetComponent component, long currentTick) {
+        if (component == null) {
+            return;
+        }
+        UUID ownerId = component.getOwnerUuid();
+        if (ownerId == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.computeIfAbsent(ownerId, OwnerProcessingGroup::new);
+        membership.put(component, ownerId);
+        group.markPetChanged(component, currentTick);
+    }
+
+    public void onTaskScheduled(PetComponent component, PetWorkScheduler.TaskType type, long tick) {
+        if (component == null) {
+            return;
+        }
+        UUID ownerId = component.getOwnerUuid();
+        if (ownerId == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.computeIfAbsent(ownerId, OwnerProcessingGroup::new);
+        membership.put(component, ownerId);
+        OwnerEventType eventType = OwnerEventType.fromTaskType(type);
+        boolean eventEnabled = isEventActive(eventType);
+        group.onTaskScheduled(component, type, tick, eventEnabled);
+        if (eventEnabled && eventType != null) {
+            scheduleEventGroup(group);
+        }
+    }
+
+    public void onTaskExecuted(PetComponent component, PetWorkScheduler.TaskType type, long tick) {
+        if (component == null) {
+            return;
+        }
+        UUID ownerId = membership.get(component);
+        if (ownerId == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.get(ownerId);
+        if (group != null) {
+            OwnerEventType eventType = OwnerEventType.fromTaskType(type);
+            boolean eventEnabled = isEventActive(eventType);
+            group.onTaskExecuted(component, type, tick, eventEnabled);
+            if (eventEnabled && eventType != null) {
+                scheduleEventGroup(group);
+            }
+        }
+    }
+
+    public void onTasksCleared(PetComponent component) {
+        if (component == null) {
+            return;
+        }
+        UUID ownerId = membership.get(component);
+        if (ownerId == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.get(ownerId);
+        if (group != null) {
+            group.onTasksCleared(component);
+            scheduleEventGroup(group);
+        }
+    }
+
+    public void signalMovement(PetComponent component, long currentTick) {
+        signalEvent(component, OwnerEventType.AURA, currentTick);
+        signalEvent(component, OwnerEventType.SUPPORT, currentTick);
+        signalEvent(component, OwnerEventType.MOVEMENT, currentTick);
+    }
+
+    public void signalEvent(PetComponent component, OwnerEventType type, long tick) {
+        if (component == null || type == null) {
+            return;
+        }
+        UUID ownerId = component.getOwnerUuid();
+        if (ownerId == null) {
+            return;
+        }
+        membership.put(component, ownerId);
+        OwnerProcessingGroup group = groups.computeIfAbsent(ownerId, OwnerProcessingGroup::new);
+        group.track(component);
+        boolean eventEnabled = isEventActive(type);
+        group.signalEvent(type, tick, eventEnabled);
+        if (eventEnabled) {
+            scheduleEventGroup(group);
+        }
+    }
+
+    public void signalEvent(UUID ownerId, OwnerEventType type, long tick) {
+        if (ownerId == null || type == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.computeIfAbsent(ownerId, OwnerProcessingGroup::new);
+        boolean eventEnabled = isEventActive(type);
+        group.signalEvent(type, tick, eventEnabled);
+        if (eventEnabled) {
+            scheduleEventGroup(group);
+        }
+    }
+
+    public OwnerTaskBatch createAdHocBatch(UUID ownerId, EnumSet<OwnerEventType> dueEvents, long currentTick) {
+        if (ownerId == null || dueEvents == null || dueEvents.isEmpty()) {
+            return null;
+        }
+        OwnerProcessingGroup group = groups.get(ownerId);
+        if (group == null) {
+            return null;
+        }
+        group.beginTick(currentTick);
+        return group.snapshot(dueEvents, currentTick);
+    }
+
+    public void prepareForTick(long currentTick) {
+        this.currentTick = currentTick;
+        for (OwnerProcessingGroup group : groups.values()) {
+            group.beginTick(currentTick);
+        }
+    }
+
+    public int preparePendingGroups(long currentTick) {
+        this.currentTick = currentTick;
+        promoteDueEvents();
+        return pendingQueue.size();
+    }
+
+    public void processOwnerTick(ServerPlayerEntity owner, long currentTick) {
+        OwnerProcessingGroup group = groups.get(owner.getUuid());
+        if (group != null) {
+            group.onOwnerTick(owner, currentTick);
+        }
+    }
+
+    public void enqueueTask(PetWorkScheduler.ScheduledTask task) {
+        PetComponent component = task.component();
+        if (component == null) {
+            orphanTasks.add(task);
+            return;
+        }
+        UUID ownerId = membership.get(component);
+        if (ownerId == null) {
+            ownerId = component.getOwnerUuid();
+            if (ownerId != null) {
+                membership.put(component, ownerId);
+            }
+        }
+        if (ownerId == null) {
+            orphanTasks.add(task);
+            return;
+        }
+        OwnerProcessingGroup group = groups.computeIfAbsent(ownerId, OwnerProcessingGroup::new);
+        group.track(component);
+        group.enqueue(task);
+        queueGroup(group);
+    }
+
+    public void flushBatches(BiConsumer<UUID, OwnerTaskBatch> consumer, long currentTick, int budget) {
+        this.currentTick = currentTick;
+        if (budget <= 0) {
+            processOrphanTasks(consumer, currentTick);
+            return;
+        }
+
+        int processed = 0;
+        while (processed < budget && !pendingQueue.isEmpty()) {
+            OwnerProcessingGroup group = pendingQueue.pollFirst();
+            if (group == null) {
+                continue;
+            }
+            if (groups.get(group.ownerId()) != group) {
+                continue;
+            }
+
+            group.clearPendingFlag();
+
+            boolean hasTasks = group.hasPendingTasks();
+            boolean hasDueEvents = group.hasDueEvents(currentTick);
+            if (!hasTasks && !hasDueEvents) {
+                if (group.isEmpty()) {
+                    groups.remove(group.ownerId(), group);
+                } else {
+                    scheduleEventGroup(group);
+                }
+                continue;
+            }
+
+            try (OwnerTaskBatch batch = group.drain(currentTick)) {
+                consumer.accept(group.ownerId(), batch);
+            }
+            processed++;
+
+            if (group.isEmpty()) {
+                groups.remove(group.ownerId(), group);
+            } else {
+                scheduleEventGroup(group);
+            }
+        }
+
+        processOrphanTasks(consumer, currentTick);
+    }
+
+    public void markOwnerEventExecuted(@Nullable UUID ownerId, OwnerEventType type, long tick) {
+        if (ownerId == null || type == null) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.get(ownerId);
+        if (group != null) {
+            boolean eventEnabled = isEventActive(type);
+            group.markEventExecuted(type, tick, eventEnabled);
+            if (eventEnabled) {
+                scheduleEventGroup(group);
+            }
+        }
+    }
+
+    public Collection<OwnerProcessingGroup> groups() {
+        return groups.values();
+    }
+
+    public void applySchedulingPrediction(UUID ownerId,
+                                          OwnerSchedulingPrediction prediction,
+                                          long currentTick) {
+        if (ownerId == null || prediction == null || prediction.isEmpty()) {
+            return;
+        }
+        OwnerProcessingGroup group = groups.get(ownerId);
+        if (group == null) {
+            return;
+        }
+
+        boolean changed = false;
+        for (Map.Entry<OwnerEventType, Long> entry : prediction.nextEventTicks().entrySet()) {
+            OwnerEventType type = entry.getKey();
+            if (!isEventActive(type)) {
+                continue;
+            }
+            long predictedTick = Math.max(currentTick, Math.max(0L, entry.getValue()));
+            if (group.applyPrediction(type, predictedTick)) {
+                changed = true;
+            }
+        }
+
+        if (!changed) {
+            return;
+        }
+
+        removeGroupFromDueQueue(group);
+        long nextTick = group.nextEventTick();
+        if (nextTick <= currentTick) {
+            queueGroup(group);
+        } else {
+            scheduleEventGroup(group);
+        }
+    }
+
+    private void queueGroup(@Nullable OwnerProcessingGroup group) {
+        if (group == null) {
+            return;
+        }
+        if (groups.get(group.ownerId()) != group) {
+            return;
+        }
+        if (group.markPending()) {
+            pendingQueue.addLast(group);
+        }
+    }
+
+    private void scheduleEventGroup(@Nullable OwnerProcessingGroup group) {
+        if (group == null) {
+            return;
+        }
+        long nextTick = group.nextEventTick();
+        if (nextTick == Long.MAX_VALUE) {
+            return;
+        }
+        eventDueQueue.computeIfAbsent(nextTick, ignored -> new ArrayList<>()).add(group);
+    }
+
+    private void promoteDueEvents() {
+        while (!eventDueQueue.isEmpty()) {
+            Map.Entry<Long, List<OwnerProcessingGroup>> entry = eventDueQueue.firstEntry();
+            if (entry == null || entry.getKey() > currentTick) {
+                break;
+            }
+            eventDueQueue.pollFirstEntry();
+            List<OwnerProcessingGroup> dueGroups = entry.getValue();
+            if (dueGroups == null) {
+                continue;
+            }
+            for (OwnerProcessingGroup group : dueGroups) {
+                if (group == null) {
+                    continue;
+                }
+                if (groups.get(group.ownerId()) != group) {
+                    continue;
+                }
+                long nextTick = group.nextEventTick();
+                if (nextTick > currentTick && nextTick != Long.MAX_VALUE) {
+                    scheduleEventGroup(group);
+                    continue;
+                }
+                queueGroup(group);
+            }
+        }
+    }
+
+    private void processOrphanTasks(BiConsumer<UUID, OwnerTaskBatch> consumer, long currentTick) {
+        if (orphanTasks.isEmpty()) {
+            return;
+        }
+        for (PetWorkScheduler.ScheduledTask task : orphanTasks) {
+            try (OwnerTaskBatch batch = OwnerTaskBatch.single(task, currentTick)) {
+                consumer.accept(null, batch);
+            }
+        }
+        orphanTasks.clear();
+    }
+
+    public void onListenerPresenceChanged(OwnerEventType type, boolean present) {
+        if (type == null) {
+            return;
+        }
+        Boolean previous = lastPresence.put(type, present);
+        if (previous != null && previous == present) {
+            return;
+        }
+        if (present) {
+            if (activeEvents.add(type)) {
+                for (OwnerProcessingGroup group : groups.values()) {
+                    if (group.activateDeferredEvent(type, currentTick)) {
+                        scheduleEventGroup(group);
+                    }
+                }
+            }
+        } else if (!ALWAYS_ACTIVE_EVENTS.contains(type)) {
+            if (activeEvents.remove(type)) {
+                for (OwnerProcessingGroup group : groups.values()) {
+                    if (group.deactivateEvent(type)) {
+                        removeGroupFromDueQueue(group);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isEventActive(@Nullable OwnerEventType type) {
+        if (type == null) {
+            return true;
+        }
+        return ALWAYS_ACTIVE_EVENTS.contains(type) || activeEvents.contains(type);
+    }
+
+    private void removeGroupFromDueQueue(OwnerProcessingGroup target) {
+        if (target == null || eventDueQueue.isEmpty()) {
+            return;
+        }
+        var iterator = eventDueQueue.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, List<OwnerProcessingGroup>> entry = iterator.next();
+            List<OwnerProcessingGroup> list = entry.getValue();
+            if (list == null) {
+                iterator.remove();
+                continue;
+            }
+            list.removeIf(group -> group == target);
+            if (list.isEmpty()) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public void shutdown() {
+        for (OwnerProcessingGroup group : groups.values()) {
+            group.clear();
+        }
+        groups.clear();
+        membership.clear();
+        orphanTasks.clear();
+        pendingQueue.clear();
+        eventDueQueue.clear();
+        activeEvents.clear();
+        activeEvents.addAll(ALWAYS_ACTIVE_EVENTS);
+        lastPresence.clear();
+        currentTick = 0L;
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerSchedulingPrediction.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerSchedulingPrediction.java
@@ -1,0 +1,116 @@
+package woflo.petsplus.state.processing;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import woflo.petsplus.state.PetWorkScheduler;
+
+/**
+ * Immutable container describing predicted next-run ticks for owner-scoped
+ * events. Predictions are derived from {@link OwnerBatchSnapshot} data so they
+ * can be computed safely on a background worker.
+ */
+public final class OwnerSchedulingPrediction {
+    private static final OwnerSchedulingPrediction EMPTY = new OwnerSchedulingPrediction(new EnumMap<>(OwnerEventType.class));
+
+    private final EnumMap<OwnerEventType, Long> nextEventTicks;
+
+    private OwnerSchedulingPrediction(EnumMap<OwnerEventType, Long> nextEventTicks) {
+        this.nextEventTicks = nextEventTicks;
+    }
+
+    public boolean isEmpty() {
+        return nextEventTicks.isEmpty();
+    }
+
+    public Map<OwnerEventType, Long> nextEventTicks() {
+        return nextEventTicks;
+    }
+
+    public static OwnerSchedulingPrediction empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Builds a scheduling prediction using immutable batch data captured on the
+     * main thread. Predictions favour the earliest task due dates for each owner
+     * event and fall back to a conservative interval when no explicit schedule
+     * is available.
+     */
+    public static OwnerSchedulingPrediction predict(OwnerBatchSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        EnumMap<OwnerEventType, Long> ticks = new EnumMap<>(OwnerEventType.class);
+        long snapshotTick = snapshot.snapshotTick();
+
+        Map<PetWorkScheduler.TaskType, List<OwnerBatchSnapshot.TaskSnapshot>> buckets = snapshot.taskBuckets();
+        for (Map.Entry<PetWorkScheduler.TaskType, List<OwnerBatchSnapshot.TaskSnapshot>> entry : buckets.entrySet()) {
+            PetWorkScheduler.TaskType taskType = entry.getKey();
+            if (taskType == null) {
+                continue;
+            }
+            OwnerEventType eventType = OwnerEventType.fromTaskType(taskType);
+            if (eventType == null) {
+                continue;
+            }
+            List<OwnerBatchSnapshot.TaskSnapshot> tasks = entry.getValue();
+            if (tasks == null || tasks.isEmpty()) {
+                continue;
+            }
+            long bestTick = ticks.getOrDefault(eventType, Long.MAX_VALUE);
+            for (OwnerBatchSnapshot.TaskSnapshot task : tasks) {
+                if (task == null) {
+                    continue;
+                }
+                long dueTick = clampFutureTick(task.dueTick(), snapshotTick);
+                if (dueTick < bestTick) {
+                    bestTick = dueTick;
+                }
+            }
+            if (bestTick != Long.MAX_VALUE) {
+                ticks.put(eventType, bestTick);
+            }
+        }
+
+        Set<OwnerEventType> dueEvents = snapshot.dueEvents();
+        if (dueEvents != null && !dueEvents.isEmpty()) {
+            for (OwnerEventType eventType : dueEvents) {
+                if (eventType == null) {
+                    continue;
+                }
+                long existing = ticks.getOrDefault(eventType, Long.MAX_VALUE);
+                long fallback = clampFutureTick(snapshotTick + estimateFallbackInterval(eventType), snapshotTick);
+                long chosen = existing == Long.MAX_VALUE ? fallback : Math.min(existing, fallback);
+                ticks.put(eventType, chosen);
+            }
+        }
+
+        if (ticks.isEmpty()) {
+            return empty();
+        }
+
+        return new OwnerSchedulingPrediction(new EnumMap<>(ticks));
+    }
+
+    private static long clampFutureTick(long candidate, long baseline) {
+        if (candidate <= baseline) {
+            candidate = baseline + 1L;
+        }
+        return Math.max(0L, candidate);
+    }
+
+    private static long estimateFallbackInterval(OwnerEventType type) {
+        return switch (type) {
+            case INTERVAL -> 20L;
+            case AURA -> 20L;
+            case SUPPORT -> 40L;
+            case PARTICLE -> 40L;
+            case GOSSIP -> 200L;
+            case MOVEMENT -> 5L;
+            case XP_GAIN -> 1L;
+            case ABILITY_TRIGGER -> 5L;
+        };
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerSpatialResult.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerSpatialResult.java
@@ -1,0 +1,118 @@
+package woflo.petsplus.state.processing;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Immutable spatial analysis of an owner batch captured for asynchronous
+ * processing. Results only contain primitive data so they can be safely shared
+ * between threads and replayed on the main thread without touching live world
+ * state.
+ */
+public final class OwnerSpatialResult {
+    private final UUID ownerId;
+    private final long snapshotTick;
+    private final Map<UUID, List<Neighbor>> neighborsByPet;
+
+    private OwnerSpatialResult(UUID ownerId,
+                               long snapshotTick,
+                               Map<UUID, List<Neighbor>> neighborsByPet) {
+        this.ownerId = ownerId;
+        this.snapshotTick = snapshotTick;
+        this.neighborsByPet = neighborsByPet;
+    }
+
+    public UUID ownerId() {
+        return ownerId;
+    }
+
+    public long snapshotTick() {
+        return snapshotTick;
+    }
+
+    public boolean isEmpty() {
+        return neighborsByPet.isEmpty();
+    }
+
+    /**
+     * Returns a list of neighbor pet UUIDs ordered by increasing distance. The
+     * list is capped by {@code limit} and filtered by {@code radius}.
+     */
+    public List<UUID> neighborsWithin(UUID petUuid, double radius, int limit) {
+        if (petUuid == null || radius <= 0.0D || limit <= 0) {
+            return List.of();
+        }
+        List<Neighbor> neighbors = neighborsByPet.get(petUuid);
+        if (neighbors == null || neighbors.isEmpty()) {
+            return List.of();
+        }
+        double radiusSq = radius * radius;
+        List<UUID> matches = new ArrayList<>(Math.min(limit, neighbors.size()));
+        for (Neighbor neighbor : neighbors) {
+            if (neighbor.squaredDistance() > radiusSq) {
+                break;
+            }
+            matches.add(neighbor.petUuid());
+            if (matches.size() >= limit) {
+                break;
+            }
+        }
+        return matches;
+    }
+
+    public static OwnerSpatialResult analyze(OwnerBatchSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+        List<OwnerBatchSnapshot.PetSummary> pets = snapshot.pets();
+        if (pets.isEmpty()) {
+            return new OwnerSpatialResult(snapshot.ownerId(), snapshot.snapshotTick(), Map.of());
+        }
+
+        Map<UUID, List<Neighbor>> neighbors = new HashMap<>();
+        List<OwnerBatchSnapshot.PetSummary> filtered = new ArrayList<>(pets.size());
+        for (OwnerBatchSnapshot.PetSummary pet : pets) {
+            if (pet.petUuid() == null) {
+                continue;
+            }
+            if (Double.isNaN(pet.x()) || Double.isNaN(pet.y()) || Double.isNaN(pet.z())) {
+                continue;
+            }
+            filtered.add(pet);
+            neighbors.put(pet.petUuid(), new ArrayList<>());
+        }
+
+        int size = filtered.size();
+        for (int i = 0; i < size; i++) {
+            OwnerBatchSnapshot.PetSummary left = filtered.get(i);
+            for (int j = i + 1; j < size; j++) {
+                OwnerBatchSnapshot.PetSummary right = filtered.get(j);
+                double dx = left.x() - right.x();
+                double dy = left.y() - right.y();
+                double dz = left.z() - right.z();
+                double distanceSq = (dx * dx) + (dy * dy) + (dz * dz);
+                neighbors.get(left.petUuid()).add(new Neighbor(right.petUuid(), distanceSq));
+                neighbors.get(right.petUuid()).add(new Neighbor(left.petUuid(), distanceSq));
+            }
+        }
+
+        Map<UUID, List<Neighbor>> immutable = new HashMap<>(neighbors.size());
+        for (Map.Entry<UUID, List<Neighbor>> entry : neighbors.entrySet()) {
+            List<Neighbor> list = entry.getValue();
+            list.sort((a, b) -> Double.compare(a.squaredDistance(), b.squaredDistance()));
+            immutable.put(entry.getKey(), Collections.unmodifiableList(list));
+        }
+
+        return new OwnerSpatialResult(
+            snapshot.ownerId(),
+            snapshot.snapshotTick(),
+            Collections.unmodifiableMap(immutable)
+        );
+    }
+
+    public record Neighbor(UUID petUuid, double squaredDistance) {
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/OwnerTaskBatch.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerTaskBatch.java
@@ -1,0 +1,196 @@
+package woflo.petsplus.state.processing;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import org.jetbrains.annotations.Nullable;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetWorkScheduler;
+
+/**
+ * Pooled snapshot describing the owner-scoped work that should execute for a
+ * particular tick. The batch owns the task lists until {@link #close()} is
+ * invoked, at which point they are recycled back into shared pools.
+ */
+public final class OwnerTaskBatch implements AutoCloseable {
+    private static final int MAX_POOL_SIZE = 256;
+    private static final ArrayDeque<OwnerTaskBatch> POOL = new ArrayDeque<>();
+
+    private UUID ownerId;
+    private final EnumMap<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> bucketViews =
+        new EnumMap<>(PetWorkScheduler.TaskType.class);
+    private final EnumMap<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> bucketBacking =
+        new EnumMap<>(PetWorkScheduler.TaskType.class);
+    private List<PetComponent> pets = List.of();
+    private final EnumSet<OwnerEventType> dueEvents = EnumSet.noneOf(OwnerEventType.class);
+    private final Set<OwnerEventType> dueEventsView = Collections.unmodifiableSet(dueEvents);
+    private long snapshotTick;
+    private @Nullable ServerPlayerEntity lastKnownOwner;
+    private boolean released;
+
+    private OwnerTaskBatch() {
+    }
+
+    public static OwnerTaskBatch obtain(@Nullable UUID ownerId,
+                                        long snapshotTick,
+                                        @Nullable ServerPlayerEntity lastKnownOwner) {
+        OwnerTaskBatch batch;
+        synchronized (POOL) {
+            batch = POOL.pollFirst();
+        }
+        if (batch == null) {
+            batch = new OwnerTaskBatch();
+        }
+        batch.ownerId = ownerId;
+        batch.snapshotTick = snapshotTick;
+        batch.lastKnownOwner = lastKnownOwner;
+        batch.released = false;
+        batch.pets = List.of();
+        batch.dueEvents.clear();
+        batch.bucketViews.clear();
+        batch.bucketBacking.clear();
+        return batch;
+    }
+
+    public static OwnerTaskBatch single(PetWorkScheduler.ScheduledTask task, long tick) {
+        OwnerTaskBatch batch = obtain(null, tick, null);
+        List<PetWorkScheduler.ScheduledTask> list = PooledTaskLists.borrow();
+        list.add(task);
+        batch.addBucket(task.type(), list);
+        PetComponent component = task.component();
+        batch.pets = component == null ? List.of() : List.of(component);
+        return batch;
+    }
+
+    public static OwnerTaskBatch adHoc(@Nullable UUID ownerId,
+                                       List<PetComponent> pets,
+                                       EnumSet<OwnerEventType> dueEvents,
+                                       long tick,
+                                       @Nullable ServerPlayerEntity lastKnownOwner) {
+        OwnerTaskBatch batch = obtain(ownerId, tick, lastKnownOwner);
+        batch.attachPets(pets == null || pets.isEmpty() ? List.of() : List.copyOf(pets));
+        if (dueEvents != null && !dueEvents.isEmpty()) {
+            batch.attachDueEvents(EnumSet.copyOf(dueEvents));
+        }
+        return batch;
+    }
+
+    public void addBucket(PetWorkScheduler.TaskType type, List<PetWorkScheduler.ScheduledTask> tasks) {
+        if (type == null || tasks == null || tasks.isEmpty()) {
+            return;
+        }
+        bucketBacking.put(type, tasks);
+        bucketViews.put(type, Collections.unmodifiableList(tasks));
+    }
+
+    public void attachPets(List<PetComponent> pets) {
+        this.pets = pets == null ? List.of() : pets;
+    }
+
+    public void attachDueEvents(EnumSet<OwnerEventType> events) {
+        dueEvents.clear();
+        if (events != null && !events.isEmpty()) {
+            dueEvents.addAll(events);
+        }
+    }
+
+    public UUID ownerId() {
+        return ownerId;
+    }
+
+    public List<PetComponent> pets() {
+        return pets;
+    }
+
+    public EnumSet<OwnerEventType> dueEvents() {
+        return dueEvents.isEmpty() ? EnumSet.noneOf(OwnerEventType.class) : EnumSet.copyOf(dueEvents);
+    }
+
+    public Set<OwnerEventType> dueEventsView() {
+        return dueEvents.isEmpty() ? Set.of() : dueEventsView;
+    }
+
+    public long snapshotTick() {
+        return snapshotTick;
+    }
+
+    @Nullable
+    public ServerPlayerEntity lastKnownOwner() {
+        return lastKnownOwner;
+    }
+
+    public boolean isEmpty() {
+        if (bucketBacking.isEmpty()) {
+            return true;
+        }
+        for (Map.Entry<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> entry : bucketBacking.entrySet()) {
+            List<PetWorkScheduler.ScheduledTask> tasks = entry.getValue();
+            if (tasks != null && !tasks.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void forEachTask(Consumer<PetWorkScheduler.ScheduledTask> consumer) {
+        bucketViews.forEach((type, tasks) -> {
+            if (tasks == null) {
+                return;
+            }
+            for (PetWorkScheduler.ScheduledTask task : tasks) {
+                consumer.accept(task);
+            }
+        });
+    }
+
+    public void forEachBucket(BiConsumer<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> consumer) {
+        bucketViews.forEach((type, tasks) -> {
+            if (tasks == null || tasks.isEmpty()) {
+                return;
+            }
+            consumer.accept(type, tasks);
+        });
+    }
+
+    public List<PetWorkScheduler.ScheduledTask> tasksFor(PetWorkScheduler.TaskType type) {
+        if (type == null) {
+            return List.of();
+        }
+        List<PetWorkScheduler.ScheduledTask> tasks = bucketViews.get(type);
+        return tasks == null || tasks.isEmpty() ? List.of() : tasks;
+    }
+
+    @Override
+    public void close() {
+        if (released) {
+            return;
+        }
+        released = true;
+        for (List<PetWorkScheduler.ScheduledTask> tasks : bucketBacking.values()) {
+            PooledTaskLists.recycle(tasks);
+        }
+        bucketBacking.clear();
+        bucketViews.clear();
+        pets = List.of();
+        dueEvents.clear();
+        ownerId = null;
+        snapshotTick = 0L;
+        lastKnownOwner = null;
+        synchronized (POOL) {
+            if (POOL.size() < MAX_POOL_SIZE) {
+                POOL.addFirst(this);
+            }
+        }
+    }
+}

--- a/src/main/java/woflo/petsplus/state/processing/PooledTaskLists.java
+++ b/src/main/java/woflo/petsplus/state/processing/PooledTaskLists.java
@@ -1,0 +1,45 @@
+package woflo.petsplus.state.processing;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+
+import woflo.petsplus.state.PetWorkScheduler;
+
+/**
+ * Simple synchronized pool for temporary task lists used during owner batch
+ * assembly. Reusing the {@link java.util.ArrayList} instances significantly
+ * reduces garbage generated when large swarms fan in many scheduled tasks.
+ */
+final class PooledTaskLists {
+    private static final int MAX_POOL_SIZE = 512;
+    private static final ArrayDeque<List<PetWorkScheduler.ScheduledTask>> POOL = new ArrayDeque<>();
+
+    private PooledTaskLists() {
+    }
+
+    static List<PetWorkScheduler.ScheduledTask> borrow() {
+        List<PetWorkScheduler.ScheduledTask> list;
+        synchronized (POOL) {
+            list = POOL.pollFirst();
+        }
+        if (list == null) {
+            list = new ArrayList<>(4);
+        } else {
+            list.clear();
+        }
+        return list;
+    }
+
+    static void recycle(List<PetWorkScheduler.ScheduledTask> list) {
+        if (list == null) {
+            return;
+        }
+        list.clear();
+        synchronized (POOL) {
+            if (POOL.size() < MAX_POOL_SIZE) {
+                POOL.addFirst(list);
+            }
+        }
+    }
+}

--- a/src/test/java/woflo/petsplus/abilities/AbilityManagerTest.java
+++ b/src/test/java/woflo/petsplus/abilities/AbilityManagerTest.java
@@ -1,0 +1,151 @@
+package woflo.petsplus.abilities;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import net.minecraft.util.Identifier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import woflo.petsplus.api.Ability;
+import woflo.petsplus.api.Trigger;
+import woflo.petsplus.state.processing.OwnerBatchSnapshot;
+
+class AbilityManagerTest {
+    private Map<Identifier, Object> roleEventCaches;
+    private Identifier testRole;
+
+    @BeforeEach
+    void setUpCacheField() throws Exception {
+        Field cachesField = AbilityManager.class.getDeclaredField("ROLE_EVENT_CACHES");
+        cachesField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<Identifier, Object> caches = (Map<Identifier, Object>) cachesField.get(null);
+        this.roleEventCaches = caches;
+        this.testRole = Identifier.of("petsplus", "test_role");
+    }
+
+    @AfterEach
+    void tearDownCacheEntry() {
+        roleEventCaches.remove(testRole);
+    }
+
+    @Test
+    void asyncAbilityPlansRecheckCooldownsAtApplyTime() {
+        UUID ownerId = UUID.randomUUID();
+        String trigger = "test_trigger";
+        Identifier abilityId = Identifier.of("petsplus", "test_ability");
+        String cooldownKey = abilityId.toString();
+
+        Trigger triggerImpl = new Trigger() {
+            private final Identifier id = Identifier.of("petsplus", trigger);
+
+            @Override
+            public Identifier getId() {
+                return id;
+            }
+
+            @Override
+            public boolean shouldActivate(woflo.petsplus.api.TriggerContext context) {
+                return true;
+            }
+        };
+        Ability ability = new Ability(abilityId, triggerImpl, List.of(), null);
+
+        try {
+            Class<?> cacheClass = Class.forName("woflo.petsplus.abilities.AbilityManager$RoleAbilityCache");
+            var buildMethod = cacheClass.getDeclaredMethod("build", List.class, Map.class, List.class);
+            buildMethod.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Object cache = buildMethod.invoke(null, List.of(ability), Map.of(trigger, List.of(ability)), List.of());
+            roleEventCaches.put(testRole, cache);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to build role ability cache", exception);
+        }
+
+        Map<String, Long> cooldownSnapshotMap = Map.of(cooldownKey, 100L);
+        OwnerBatchSnapshot.PetSummary summary = new OwnerBatchSnapshot.PetSummary(
+            UUID.randomUUID(),
+            testRole,
+            5,
+            0L,
+            false,
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            cooldownSnapshotMap
+        );
+
+        OwnerBatchSnapshot snapshot = createSnapshot(ownerId, List.of(summary), 80L);
+
+        AbilityTriggerPayload payload = AbilityTriggerPayload.of(trigger, Map.of());
+        AbilityManager.AbilityExecutionPlan plan = AbilityManager.prepareOwnerExecutionPlan(snapshot, payload);
+        assertFalse(plan.isEmpty(), "Ability plan should retain abilities that were cooling down at snapshot time");
+
+        AbilityManager.AbilityExecutionPlan.PetExecution execution = plan.executions().get(0);
+        Map<String, Long> cooldownSnapshot = execution.cooldowns();
+
+        List<?> filteredAtSnapshot = invokeCooldownFilter(execution.abilities(), cooldownSnapshot, 80L);
+        assertTrue(filteredAtSnapshot.isEmpty(), "Snapshot tick should still treat ability as cooling down");
+
+        List<?> filteredAtApply = invokeCooldownFilter(execution.abilities(), cooldownSnapshot, 120L);
+        assertFalse(filteredAtApply.isEmpty(), "Application tick should allow ability to execute");
+
+        Object compiled = filteredAtApply.get(0);
+        try {
+            var abilityMethod = compiled.getClass().getDeclaredMethod("ability");
+            abilityMethod.setAccessible(true);
+            Object compiledAbility = abilityMethod.invoke(compiled);
+            assertTrue(compiledAbility == ability, "Compiled ability should reference the prepared ability instance");
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to inspect compiled ability", exception);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<?> invokeCooldownFilter(List<?> abilities, Map<String, Long> cooldowns, long tick) {
+        try {
+            var method = AbilityManager.class.getDeclaredMethod(
+                "filterAbilitiesByCooldown",
+                List.class,
+                Map.class,
+                long.class
+            );
+            method.setAccessible(true);
+            return (List<?>) method.invoke(null, abilities, cooldowns, tick);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to invoke cooldown filter", exception);
+        }
+    }
+
+    private static OwnerBatchSnapshot createSnapshot(UUID ownerId, List<OwnerBatchSnapshot.PetSummary> pets, long snapshotTick) {
+        try {
+            var constructor = OwnerBatchSnapshot.class.getDeclaredConstructor(
+                UUID.class,
+                long.class,
+                UUID.class,
+                java.util.Set.class,
+                Map.class,
+                List.class
+            );
+            constructor.setAccessible(true);
+            return constructor.newInstance(
+                ownerId,
+                snapshotTick,
+                null,
+                java.util.Set.of(),
+                Map.of(),
+                pets
+            );
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to construct snapshot", exception);
+        }
+    }
+}

--- a/src/test/java/woflo/petsplus/abilities/OwnerAbilityEventBridgeTest.java
+++ b/src/test/java/woflo/petsplus/abilities/OwnerAbilityEventBridgeTest.java
@@ -1,0 +1,156 @@
+package woflo.petsplus.abilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.DoubleSupplier;
+
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import org.junit.jupiter.api.Test;
+
+import sun.misc.Unsafe;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.StateManager;
+import woflo.petsplus.state.processing.AsyncWorkCoordinator;
+import woflo.petsplus.state.processing.OwnerBatchSnapshot;
+import woflo.petsplus.state.processing.OwnerEventFrame;
+import woflo.petsplus.state.processing.OwnerEventType;
+import woflo.petsplus.state.processing.OwnerTaskBatch;
+
+class OwnerAbilityEventBridgeTest {
+
+    @Test
+    void asyncRejectionFallsBackToSynchronousDispatch() throws Exception {
+        AsyncWorkCoordinator coordinator = throttledCoordinator();
+        StateManager manager = allocate(StateManager.class);
+
+        setStateManagerField(manager, "asyncWorkCoordinator", coordinator);
+
+        UUID ownerId = UUID.randomUUID();
+        PetComponent pet = allocate(PetComponent.class);
+        List<PetComponent> pets = List.of(pet);
+
+        OwnerTaskBatch batch = OwnerTaskBatch.adHoc(ownerId, pets, EnumSet.of(OwnerEventType.ABILITY_TRIGGER), 42L, null);
+        OwnerBatchSnapshot snapshot = emptySnapshot(ownerId);
+        AbilityTriggerPayload payload = AbilityTriggerPayload.of("test_trigger", Map.of("value", 1));
+
+        OwnerEventFrame frame = frameWithPets(pets, ownerId, payload);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<List<PetComponent>> dispatchedPets = new AtomicReference<>();
+        AtomicReference<String> dispatchedTrigger = new AtomicReference<>();
+        AtomicReference<Map<String, Object>> dispatchedData = new AtomicReference<>();
+
+        OwnerAbilityEventBridge.setAbilityExecutorForTesting((eventWorld, owner, eventPets, trigger, data) -> {
+            dispatchedPets.set(eventPets);
+            dispatchedTrigger.set(trigger);
+            dispatchedData.set(data);
+            latch.countDown();
+        });
+
+        try {
+            Method method = OwnerAbilityEventBridge.class.getDeclaredMethod(
+                "dispatchAsync",
+                StateManager.class,
+                OwnerEventFrame.class,
+                OwnerBatchSnapshot.class,
+                AbilityTriggerPayload.class,
+                String.class
+            );
+            method.setAccessible(true);
+
+            method.invoke(OwnerAbilityEventBridge.INSTANCE, manager, frame, snapshot, payload, "test_trigger");
+
+            assertTrue(latch.await(1, TimeUnit.SECONDS), "Fallback dispatcher should run synchronously");
+
+            assertEquals("test_trigger", dispatchedTrigger.get(), "Fallback should reuse trigger id");
+            assertEquals(pets, dispatchedPets.get(), "Fallback should retain pet list snapshot");
+            assertEquals(payload.eventData(), dispatchedData.get(), "Fallback should reuse payload data");
+        } finally {
+            OwnerAbilityEventBridge.setAbilityExecutorForTesting(null);
+            batch.close();
+            coordinator.close();
+        }
+    }
+
+    private static OwnerBatchSnapshot emptySnapshot(UUID ownerId) throws Exception {
+        Constructor<OwnerBatchSnapshot> constructor = OwnerBatchSnapshot.class.getDeclaredConstructor(
+            UUID.class,
+            long.class,
+            UUID.class,
+            java.util.Set.class,
+            Map.class,
+            List.class
+        );
+        constructor.setAccessible(true);
+        return constructor.newInstance(
+            ownerId,
+            21L,
+            null,
+            java.util.Set.of(OwnerEventType.ABILITY_TRIGGER),
+            Map.of(),
+            List.of()
+        );
+    }
+
+    private static AsyncWorkCoordinator throttledCoordinator() throws Exception {
+        Constructor<AsyncWorkCoordinator> constructor = AsyncWorkCoordinator.class.getDeclaredConstructor(
+            DoubleSupplier.class,
+            Executor.class
+        );
+        constructor.setAccessible(true);
+        return constructor.newInstance((DoubleSupplier) () -> 2.0D, (Executor) Runnable::run);
+    }
+
+    private static <T> T allocate(Class<T> type) throws Exception {
+        return type.cast(unsafe().allocateInstance(type));
+    }
+
+    private static void setStateManagerField(Object target, String name, Object value) throws Exception {
+        Unsafe unsafe = unsafe();
+        Field field = StateManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        unsafe.putObject(target, unsafe.objectFieldOffset(field), value);
+    }
+
+    private static OwnerEventFrame frameWithPets(List<PetComponent> pets,
+                                                 UUID ownerId,
+                                                 AbilityTriggerPayload payload) throws Exception {
+        Constructor<OwnerEventFrame> constructor = OwnerEventFrame.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        OwnerEventFrame frame = constructor.newInstance();
+
+        setFrameField(frame, "eventType", OwnerEventType.ABILITY_TRIGGER);
+        setFrameField(frame, "owner", (ServerPlayerEntity) null);
+        setFrameField(frame, "ownerId", ownerId);
+        setFrameField(frame, "pets", pets);
+        setFrameField(frame, "payload", payload);
+
+        return frame;
+    }
+
+    private static void setFrameField(OwnerEventFrame frame, String name, Object value) throws Exception {
+        Field field = OwnerEventFrame.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(frame, value);
+    }
+
+    private static Unsafe unsafe() throws Exception {
+        Field field = Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (Unsafe) field.get(null);
+    }
+}

--- a/src/test/java/woflo/petsplus/state/processing/AsyncWorkCoordinatorTest.java
+++ b/src/test/java/woflo/petsplus/state/processing/AsyncWorkCoordinatorTest.java
@@ -1,0 +1,137 @@
+package woflo.petsplus.state.processing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import woflo.petsplus.state.PetWorkScheduler;
+import woflo.petsplus.state.processing.AsyncProcessingTelemetry;
+
+class AsyncWorkCoordinatorTest {
+
+    private final AsyncWorkCoordinator coordinator = new AsyncWorkCoordinator(() -> 1.0D, Runnable::run);
+
+    @AfterEach
+    void shutdown() {
+        coordinator.close();
+    }
+
+    @Test
+    void applierRunsEvenWhenJobReturnsNull() throws Exception {
+        OwnerBatchSnapshot snapshot = emptySnapshot();
+        AtomicBoolean applied = new AtomicBoolean(false);
+
+        CompletableFuture<?> future = coordinator.submitOwnerBatch(
+            snapshot,
+            ignored -> null,
+            ignored -> applied.set(true)
+        );
+
+        try {
+            future.get();
+        } catch (ExecutionException ex) {
+            throw new AssertionError("Unexpected async failure", ex.getCause());
+        }
+
+        assertTrue(applied.get(), "Applier should run even when async job returns null");
+    }
+
+    @Test
+    void rejectedExecutionCompletesFutureExceptionally() throws Exception {
+        AsyncWorkCoordinator shuttingDown = new AsyncWorkCoordinator(() -> 1.0D, Runnable::run);
+        shuttingDown.close();
+
+        CompletableFuture<?> future = shuttingDown.submitOwnerBatch(
+            emptySnapshot(),
+            ignored -> null,
+            ignored -> {}
+        );
+
+        ExecutionException failure = assertThrows(ExecutionException.class, future::get);
+        assertTrue(failure.getCause() instanceof RejectedExecutionException,
+            "Expected RejectedExecutionException when executor is shut down");
+
+        AsyncProcessingTelemetry.TelemetrySnapshot snapshot = shuttingDown.telemetry().snapshotAndReset();
+        assertEquals(0L, snapshot.throttledSubmissions(), "No throttles expected when executor rejects directly");
+        assertEquals(1L, snapshot.rejectedSubmissions(), "Executor rejection should be recorded");
+    }
+
+    @Test
+    void throttledSubmissionRecordedWhenLoadFactorTooHigh() throws Exception {
+        AsyncWorkCoordinator throttled = new AsyncWorkCoordinator(() -> 2.0D, Runnable::run);
+
+        CompletableFuture<?> future = throttled.submitOwnerBatch(
+            emptySnapshot(),
+            ignored -> null,
+            ignored -> {}
+        );
+
+        ExecutionException failure = assertThrows(ExecutionException.class, future::get);
+        assertTrue(failure.getCause() instanceof RejectedExecutionException,
+            "Expected rejection when load factor disallows async work");
+
+        AsyncProcessingTelemetry.TelemetrySnapshot snapshot = throttled.telemetry().snapshotAndReset();
+        assertEquals(1L, snapshot.throttledSubmissions(), "Throttle should be recorded");
+        assertEquals(0L, snapshot.rejectedSubmissions(), "No executor rejection expected");
+
+        throttled.close();
+    }
+
+    @Test
+    void standaloneThrottleIncludesDescriptorInFailureMessage() throws Exception {
+        AsyncWorkCoordinator throttled = new AsyncWorkCoordinator(() -> 2.0D, Runnable::run);
+
+        CompletableFuture<?> future = throttled.submitStandalone(
+            "mood-score",
+            () -> null,
+            ignored -> {}
+        );
+
+        ExecutionException failure = assertThrows(ExecutionException.class, future::get);
+        assertTrue(failure.getCause() instanceof RejectedExecutionException,
+            "Expected rejection when load factor disallows async work");
+        assertTrue(failure.getCause().getMessage().contains("mood-score"),
+            "Descriptor should be present in rejection message");
+
+        AsyncProcessingTelemetry.TelemetrySnapshot snapshot = throttled.telemetry().snapshotAndReset();
+        assertEquals(1L, snapshot.throttledSubmissions(), "Throttle should be recorded");
+        assertEquals(0L, snapshot.rejectedSubmissions(), "Executor rejection expected to be zero");
+
+        throttled.close();
+    }
+
+    private static OwnerBatchSnapshot emptySnapshot() throws Exception {
+        Constructor<OwnerBatchSnapshot> constructor = OwnerBatchSnapshot.class.getDeclaredConstructor(
+            UUID.class,
+            long.class,
+            UUID.class,
+            Set.class,
+            java.util.Map.class,
+            List.class
+        );
+        constructor.setAccessible(true);
+        return constructor.newInstance(
+            UUID.randomUUID(),
+            0L,
+            null,
+            Collections.emptySet(),
+            new EnumMap<>(PetWorkScheduler.TaskType.class),
+            List.of()
+        );
+    }
+}
+

--- a/src/test/java/woflo/petsplus/state/processing/OwnerProcessingManagerTest.java
+++ b/src/test/java/woflo/petsplus/state/processing/OwnerProcessingManagerTest.java
@@ -1,0 +1,93 @@
+package woflo.petsplus.state.processing;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import woflo.petsplus.state.PetComponent;
+import woflo.petsplus.state.PetWorkScheduler;
+import woflo.petsplus.state.processing.OwnerTaskBatch;
+
+class OwnerProcessingManagerTest {
+
+    @Test
+    void untrackPetRemovesEmptyGroupAfterDrain() throws Exception {
+        OwnerProcessingManager manager = new OwnerProcessingManager();
+        UUID ownerId = UUID.randomUUID();
+
+        PetComponent component = mock(PetComponent.class);
+        when(component.getOwnerUuid()).thenReturn(ownerId);
+        when(component.getPetEntity()).thenReturn(null);
+
+        OwnerProcessingGroup group = new OwnerProcessingGroup(ownerId);
+        injectGroup(manager, group);
+        injectMembership(manager, component, ownerId);
+
+        PetWorkScheduler.ScheduledTask task = mock(PetWorkScheduler.ScheduledTask.class);
+        when(task.component()).thenReturn(component);
+        when(task.type()).thenReturn(PetWorkScheduler.TaskType.INTERVAL);
+
+        group.enqueue(task);
+        try (OwnerTaskBatch batch = group.drain(0L)) {
+            // drain to hand the list to the batch; closing recycles it
+        }
+
+        manager.untrackPet(component);
+
+        Map<UUID, ?> groups = extractGroups(manager);
+        assertFalse(groups.containsKey(ownerId), "Owner group should be removed after last pet is untracked");
+    }
+
+    @Test
+    void shutdownClearsManagerState() throws Exception {
+        OwnerProcessingManager manager = new OwnerProcessingManager();
+        UUID ownerId = UUID.randomUUID();
+
+        PetComponent component = mock(PetComponent.class);
+        OwnerProcessingGroup group = new OwnerProcessingGroup(ownerId);
+        injectGroup(manager, group);
+        injectMembership(manager, component, ownerId);
+
+        assertFalse(extractGroups(manager).isEmpty(), "Precondition: groups should contain owner before shutdown");
+        assertFalse(extractMembership(manager).isEmpty(), "Precondition: membership should contain entries before shutdown");
+
+        manager.shutdown();
+
+        assertTrue(extractGroups(manager).isEmpty(), "Groups should be cleared during shutdown");
+        assertTrue(extractMembership(manager).isEmpty(), "Membership should be cleared during shutdown");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<UUID, ?> extractGroups(OwnerProcessingManager manager) throws Exception {
+        Field field = OwnerProcessingManager.class.getDeclaredField("groups");
+        field.setAccessible(true);
+        return (Map<UUID, ?>) field.get(manager);
+    }
+
+    private static void injectGroup(OwnerProcessingManager manager, OwnerProcessingGroup group) throws Exception {
+        Map<UUID, OwnerProcessingGroup> groups = (Map<UUID, OwnerProcessingGroup>) extractGroups(manager);
+        groups.put(group.ownerId(), group);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void injectMembership(OwnerProcessingManager manager, PetComponent component, UUID ownerId) throws Exception {
+        Field field = OwnerProcessingManager.class.getDeclaredField("membership");
+        field.setAccessible(true);
+        Map<PetComponent, UUID> membership = (Map<PetComponent, UUID>) field.get(manager);
+        membership.put(component, ownerId);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<PetComponent, UUID> extractMembership(OwnerProcessingManager manager) throws Exception {
+        Field field = OwnerProcessingManager.class.getDeclaredField("membership");
+        field.setAccessible(true);
+        return (Map<PetComponent, UUID>) field.get(manager);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce an AsyncWorkCoordinator with load-aware throttling, double-buffered result queues, and telemetry so background owner jobs can return to the main thread deterministically while capturing queue and timing metrics.
- Capture immutable owner batch snapshots, manage per-owner event queues, and integrate the new pipeline into StateManager so swarms, tasks, and interval work are processed owner-first before dispatching results.
- Rework the ability pipeline to prepare execution plans asynchronously from owner snapshots while applying them on the main thread with captured fallback contexts to avoid reusing pooled event frames.
- Add unit tests covering cooldown rechecks, async rejection fallbacks, coordinator throttling semantics, and owner-group cleanup to validate the new infrastructure.

## Testing
- ./gradlew test