### PR TITLE
Align sacrilege advancement stat key

### DIFF
--- a/src/main/generated/data/petsplus/advancement/sacrilege.json
+++ b/src/main/generated/data/petsplus/advancement/sacrilege.json
@@ -4,7 +4,7 @@
     "guardian_tank_damage": {
       "conditions": {
         "min_value": 1000.0,
-        "stat_type": "damage_taken"
+        "stat_type": "guardian_damage_redirected"
       },
       "trigger": "petsplus:pet_stat_threshold"
     }

--- a/src/main/java/woflo/petsplus/datagen/PetsplusAdvancementProvider.java
+++ b/src/main/java/woflo/petsplus/datagen/PetsplusAdvancementProvider.java
@@ -561,7 +561,7 @@ public class PetsplusAdvancementProvider extends FabricAdvancementProvider {
             .criterion("guardian_tank_damage", new AdvancementCriterion<>(AdvancementCriteriaRegistry.PET_STAT_THRESHOLD,
                 new PetStatThresholdCriterion.Conditions(
                     Optional.empty(),
-                    Optional.of("damage_taken"),
+                    Optional.of(PetStatThresholdCriterion.STAT_GUARDIAN_DAMAGE),
                     Optional.of(1000.0f),
                     Optional.empty()
                 )))

--- a/src/main/java/woflo/petsplus/roles/guardian/GuardianCore.java
+++ b/src/main/java/woflo/petsplus/roles/guardian/GuardianCore.java
@@ -8,6 +8,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import woflo.petsplus.Petsplus;
 import woflo.petsplus.abilities.AbilityManager;
+import woflo.petsplus.advancement.criteria.PetStatThresholdCriterion;
 import woflo.petsplus.api.registry.PetRoleType;
 import woflo.petsplus.api.TriggerContext;
 import woflo.petsplus.state.OwnerCombatState;
@@ -205,7 +206,7 @@ public final class GuardianCore {
         float totalDamage = advState.getGuardianDamageRedirected();
         woflo.petsplus.advancement.AdvancementCriteriaRegistry.PET_STAT_THRESHOLD.trigger(
             owner,
-            "damage_taken",
+            PetStatThresholdCriterion.STAT_GUARDIAN_DAMAGE,
             totalDamage
         );
 


### PR DESCRIPTION
## Summary
- swap the guardian redirect advancement tracking to use the shared guardian damage stat key
- update the Sacrilege advancement generator and generated data to reference the same stat id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db55c64880832f98fb9655bda5bad6