### PR TITLE
Align healing magic stat key usage

### DIFF
--- a/src/main/generated/data/petsplus/advancement/mmm_healing_magic.json
+++ b/src/main/generated/data/petsplus/advancement/mmm_healing_magic.json
@@ -4,7 +4,7 @@
     "support_heal_allies": {
       "conditions": {
         "min_value": 5.0,
-        "stat_type": "allies_healed"
+        "stat_type": "unique_allies_healed"
       },
       "trigger": "petsplus:pet_stat_threshold"
     }

--- a/src/main/java/woflo/petsplus/datagen/PetsplusAdvancementProvider.java
+++ b/src/main/java/woflo/petsplus/datagen/PetsplusAdvancementProvider.java
@@ -580,7 +580,7 @@ public class PetsplusAdvancementProvider extends FabricAdvancementProvider {
             .criterion("support_heal_allies", new AdvancementCriterion<>(AdvancementCriteriaRegistry.PET_STAT_THRESHOLD,
                 new PetStatThresholdCriterion.Conditions(
                     Optional.empty(),
-                    Optional.of("allies_healed"),
+                    Optional.of(PetStatThresholdCriterion.STAT_ALLIES_HEALED),
                     Optional.of(5.0f),
                     Optional.empty()
                 )))

--- a/src/main/java/woflo/petsplus/effects/SupportPotionPulseEffect.java
+++ b/src/main/java/woflo/petsplus/effects/SupportPotionPulseEffect.java
@@ -18,6 +18,7 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.entry.RegistryEntry;
 import org.jetbrains.annotations.Nullable;
 import woflo.petsplus.advancement.AdvancementCriteriaRegistry;
+import woflo.petsplus.advancement.criteria.PetStatThresholdCriterion;
 import woflo.petsplus.api.Effect;
 import woflo.petsplus.api.EffectContext;
 import woflo.petsplus.api.registry.PetRoleType;
@@ -213,7 +214,7 @@ public class SupportPotionPulseEffect implements Effect {
                         int uniqueAllies = advState.getUniqueAlliesHealed();
                         woflo.petsplus.advancement.AdvancementCriteriaRegistry.PET_STAT_THRESHOLD.trigger(
                             serverOwner,
-                            "allies_healed",
+                            PetStatThresholdCriterion.STAT_ALLIES_HEALED,
                             (float) uniqueAllies
                         );
                     }


### PR DESCRIPTION
## Summary
- update SupportPotionPulseEffect to emit the PetStatThresholdCriterion.STAT_ALLIES_HEALED stat key
- use the same stat key in PetsplusAdvancementProvider when defining the mmm_healing_magic advancement
- refresh generated advancement data to match the new stat key

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db55da909c832f8cb573a69aa31793