### PR TITLE
Prevent role advancements matching without role

### DIFF
--- a/src/main/java/woflo/petsplus/advancement/criteria/PetLevelCriterion.java
+++ b/src/main/java/woflo/petsplus/advancement/criteria/PetLevelCriterion.java
@@ -60,7 +60,10 @@ public class PetLevelCriterion extends AbstractCriterion<PetLevelCriterion.Condi
             }
 
             // Check role if specified
-            if (role.isPresent() && petRoleId != null) {
+            if (role.isPresent()) {
+                if (petRoleId == null) {
+                    return false;
+                }
                 return role.get().equals(petRoleId);
             }
 

--- a/src/test/java/net/minecraft/advancement/criterion/AbstractCriterion.java
+++ b/src/test/java/net/minecraft/advancement/criterion/AbstractCriterion.java
@@ -1,0 +1,7 @@
+package net.minecraft.advancement.criterion;
+
+/** Minimal stub of AbstractCriterion for unit testing. */
+public abstract class AbstractCriterion<T extends AbstractCriterion.Conditions> {
+    public interface Conditions {
+    }
+}

--- a/src/test/java/net/minecraft/predicate/entity/EntityPredicate.java
+++ b/src/test/java/net/minecraft/predicate/entity/EntityPredicate.java
@@ -1,0 +1,11 @@
+package net.minecraft.predicate.entity;
+
+import com.mojang.serialization.Codec;
+
+/** Minimal stub of EntityPredicate for unit testing. */
+public final class EntityPredicate {
+    public static final Codec<LootContextPredicate> LOOT_CONTEXT_PREDICATE_CODEC = Codec.unit(new LootContextPredicate());
+
+    private EntityPredicate() {
+    }
+}

--- a/src/test/java/net/minecraft/predicate/entity/LootContextPredicate.java
+++ b/src/test/java/net/minecraft/predicate/entity/LootContextPredicate.java
@@ -1,0 +1,5 @@
+package net.minecraft.predicate.entity;
+
+/** Minimal stub of LootContextPredicate for unit testing. */
+public class LootContextPredicate {
+}

--- a/src/test/java/woflo/petsplus/advancement/criteria/PetLevelCriterionTest.java
+++ b/src/test/java/woflo/petsplus/advancement/criteria/PetLevelCriterionTest.java
@@ -1,0 +1,35 @@
+package woflo.petsplus.advancement.criteria;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PetLevelCriterionTest {
+
+    @Test
+    void roleSpecificCriterionDoesNotMatchWhenRoleMissing() {
+        PetLevelCriterion.Conditions conditions = new PetLevelCriterion.Conditions(
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of("support")
+        );
+
+        assertFalse(conditions.matches(5, null));
+    }
+
+    @Test
+    void roleSpecificCriterionMatchesWhenRoleMatches() {
+        PetLevelCriterion.Conditions conditions = new PetLevelCriterion.Conditions(
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of("support")
+        );
+
+        assertTrue(conditions.matches(5, "support"));
+    }
+}


### PR DESCRIPTION
## Summary
- prevent pet level advancement conditions from matching when the configured role is missing on the pet
- add unit coverage for role-specific matching and provide minimal Minecraft stubs needed for testing

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68db55a10b78832fb6d9ec83e24a3407