### PR TITLE
Guard mood advancement criteria against null mood values

### DIFF
--- a/src/main/java/woflo/petsplus/advancement/criteria/PetMoodLevelCriterion.java
+++ b/src/main/java/woflo/petsplus/advancement/criteria/PetMoodLevelCriterion.java
@@ -53,7 +53,10 @@ public class PetMoodLevelCriterion extends AbstractCriterion<PetMoodLevelCriteri
 
         public boolean matches(PetComponent.Mood petMood, int moodLevel) {
             // Check mood type if specified
-            if (mood.isPresent() && petMood != null) {
+            if (mood.isPresent()) {
+                if (petMood == null) {
+                    return false;
+                }
                 if (!mood.get().equalsIgnoreCase(petMood.name())) {
                     return false;
                 }

--- a/src/main/java/woflo/petsplus/advancement/criteria/PetMoodTransitionCriterion.java
+++ b/src/main/java/woflo/petsplus/advancement/criteria/PetMoodTransitionCriterion.java
@@ -63,7 +63,10 @@ public class PetMoodTransitionCriterion extends AbstractCriterion<PetMoodTransit
         public boolean matches(PetComponent.Mood from, int fromLvl,
                               PetComponent.Mood to, int toLvl, long ticks) {
             // Check from mood
-            if (fromMood.isPresent() && from != null) {
+            if (fromMood.isPresent()) {
+                if (from == null) {
+                    return false;
+                }
                 if (!fromMood.get().equalsIgnoreCase(from.name())) {
                     return false;
                 }
@@ -75,7 +78,10 @@ public class PetMoodTransitionCriterion extends AbstractCriterion<PetMoodTransit
             }
 
             // Check to mood
-            if (toMood.isPresent() && to != null) {
+            if (toMood.isPresent()) {
+                if (to == null) {
+                    return false;
+                }
                 if (!toMood.get().equalsIgnoreCase(to.name())) {
                     return false;
                 }


### PR DESCRIPTION
## Summary
- return early when mood filters are provided but the runtime mood is missing in the mood level criterion
- apply the same null guards for from/to mood filters in the mood transition criterion to avoid false matches

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68db55aeede0832faad0c30c46220517