### PR TITLE
Align dream escape advancements with interaction trigger

### DIFF
--- a/src/main/resources/data/petsplus/advancements/at_what_cost.json
+++ b/src/main/resources/data/petsplus/advancements/at_what_cost.json
@@ -1,7 +1,9 @@
 {
+  "parent": "petsplus:noo_luna",
   "display": {
     "icon": {
-      "item": "minecraft:gray_bed"
+      "count": 1,
+      "id": "minecraft:crying_obsidian"
     },
     "title": {
       "translate": "petsplus.adv.at_what_cost.title"
@@ -14,14 +16,18 @@
     "announce_to_chat": true,
     "hidden": false
   },
-  "parent": "petsplus:noo_luna",
   "criteria": {
-    "requirement": {
-      "trigger": "petsplus:pet_stat_threshold",
+    "dream_escape_2": {
+      "trigger": "petsplus:pet_interaction",
       "conditions": {
-        "stat_type": "dream_escapes",
-        "min_value": 3.0
+        "interaction_type": "dream_escape",
+        "min_count": 2
       }
     }
-  }
+  },
+  "requirements": [
+    [
+      "dream_escape_2"
+    ]
+  ]
 }

--- a/src/main/resources/data/petsplus/advancements/heartless_but_alive.json
+++ b/src/main/resources/data/petsplus/advancements/heartless_but_alive.json
@@ -1,7 +1,9 @@
 {
+  "parent": "petsplus:at_what_cost",
   "display": {
     "icon": {
-      "item": "minecraft:black_bed"
+      "count": 1,
+      "id": "minecraft:wither_skeleton_skull"
     },
     "title": {
       "translate": "petsplus.adv.heartless_but_alive.title"
@@ -14,14 +16,18 @@
     "announce_to_chat": true,
     "hidden": false
   },
-  "parent": "petsplus:at_what_cost",
   "criteria": {
-    "requirement": {
-      "trigger": "petsplus:pet_stat_threshold",
+    "dream_escape_3": {
+      "trigger": "petsplus:pet_interaction",
       "conditions": {
-        "stat_type": "dream_escapes",
-        "min_value": 10.0
+        "interaction_type": "dream_escape",
+        "min_count": 3
       }
     }
-  }
+  },
+  "requirements": [
+    [
+      "dream_escape_3"
+    ]
+  ]
 }

--- a/src/main/resources/data/petsplus/advancements/noo_luna.json
+++ b/src/main/resources/data/petsplus/advancements/noo_luna.json
@@ -1,7 +1,9 @@
 {
+  "parent": "petsplus:first_pet",
   "display": {
     "icon": {
-      "item": "minecraft:red_bed"
+      "count": 1,
+      "id": "minecraft:totem_of_undying"
     },
     "title": {
       "translate": "petsplus.adv.noo_luna.title"
@@ -9,19 +11,23 @@
     "description": {
       "translate": "petsplus.adv.noo_luna.desc"
     },
-    "frame": "goal",
+    "frame": "task",
     "show_toast": true,
     "announce_to_chat": true,
     "hidden": false
   },
-  "parent": "petsplus:trial_ready",
   "criteria": {
-    "requirement": {
-      "trigger": "petsplus:pet_stat_threshold",
+    "dream_escape": {
+      "trigger": "petsplus:pet_interaction",
       "conditions": {
-        "stat_type": "dream_escapes",
-        "min_value": 1.0
+        "interaction_type": "dream_escape",
+        "min_count": 1
       }
     }
-  }
+  },
+  "requirements": [
+    [
+      "dream_escape"
+    ]
+  ]
 }


### PR DESCRIPTION
## Summary
- switch the Dream's Escape advancement criteria to use the pet interaction trigger with the correct counts
- sync the authored advancement JSON with the generator output for icons, parents, and requirement names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db55e7269c832fbef92a49652115b3