### PR TITLE
Update Is This Designer advancement trigger

### DIFF
--- a/src/main/java/woflo/petsplus/advancement/AdvancementStatKeys.java
+++ b/src/main/java/woflo/petsplus/advancement/AdvancementStatKeys.java
@@ -1,0 +1,13 @@
+package woflo.petsplus.advancement;
+
+/**
+ * Shared string constants for advancement stat keys so runtime triggers and
+ * data generation stay aligned.
+ */
+public final class AdvancementStatKeys {
+    public static final String ABILITY_MAX_RANK = "ability_max_rank";
+    public static final float ABILITY_MAX_RANK_UNLOCKED_VALUE = 1.0f;
+
+    private AdvancementStatKeys() {
+    }
+}

--- a/src/main/java/woflo/petsplus/datagen/PetsplusAdvancementProvider.java
+++ b/src/main/java/woflo/petsplus/datagen/PetsplusAdvancementProvider.java
@@ -3,10 +3,10 @@ package woflo.petsplus.datagen;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricAdvancementProvider;
 import net.minecraft.advancement.Advancement;
+import net.minecraft.advancement.AdvancementCriterion;
 import net.minecraft.advancement.AdvancementEntry;
 import net.minecraft.advancement.AdvancementFrame;
 import net.minecraft.advancement.AdvancementRequirements;
-import net.minecraft.advancement.AdvancementCriterion;
 import net.minecraft.item.Items;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.text.Text;
@@ -14,6 +14,9 @@ import net.minecraft.util.Identifier;
 import woflo.petsplus.Petsplus;
 import woflo.petsplus.advancement.AdvancementCriteriaRegistry;
 import woflo.petsplus.advancement.criteria.*;
+
+import static woflo.petsplus.advancement.AdvancementStatKeys.ABILITY_MAX_RANK;
+import static woflo.petsplus.advancement.AdvancementStatKeys.ABILITY_MAX_RANK_UNLOCKED_VALUE;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -599,8 +602,8 @@ public class PetsplusAdvancementProvider extends FabricAdvancementProvider {
             .criterion("ability_max_rank", new AdvancementCriterion<>(AdvancementCriteriaRegistry.PET_STAT_THRESHOLD,
                 new PetStatThresholdCriterion.Conditions(
                     Optional.empty(),
-                    Optional.of("ability_max_rank"),
-                    Optional.of(1.0f),
+                    Optional.of(ABILITY_MAX_RANK),
+                    Optional.of(ABILITY_MAX_RANK_UNLOCKED_VALUE),
                     Optional.empty()
                 )))
             .build(consumer, Petsplus.MOD_ID + ":is_this_designer");

--- a/src/main/java/woflo/petsplus/events/TributeHandler.java
+++ b/src/main/java/woflo/petsplus/events/TributeHandler.java
@@ -19,6 +19,7 @@ import net.minecraft.util.hit.EntityHitResult;
 import org.jetbrains.annotations.Nullable;
 import woflo.petsplus.Petsplus;
 import woflo.petsplus.advancement.AdvancementCriteriaRegistry;
+import woflo.petsplus.advancement.AdvancementStatKeys;
 import woflo.petsplus.api.event.TributeCheckEvent;
 import woflo.petsplus.api.registry.PetRoleType;
 import woflo.petsplus.config.PetsPlusConfig;
@@ -207,8 +208,8 @@ public class TributeHandler {
             if (milestoneLevel == 30) {
                 AdvancementCriteriaRegistry.PET_STAT_THRESHOLD.trigger(
                     player,
-                    "ability_max_rank",
-                    1.0f
+                    AdvancementStatKeys.ABILITY_MAX_RANK,
+                    AdvancementStatKeys.ABILITY_MAX_RANK_UNLOCKED_VALUE
                 );
             }
 

--- a/src/main/resources/data/petsplus/advancements/is_this_designer.json
+++ b/src/main/resources/data/petsplus/advancements/is_this_designer.json
@@ -16,11 +16,17 @@
   },
   "parent": "petsplus:trial_ready",
   "criteria": {
-    "requirement": {
-      "trigger": "petsplus:pet_level",
+    "ability_max_rank": {
+      "trigger": "petsplus:pet_stat_threshold",
       "conditions": {
-        "min_level": 1
+        "stat_type": "ability_max_rank",
+        "min_value": 1.0
       }
     }
-  }
+  },
+  "requirements": [
+    [
+      "ability_max_rank"
+    ]
+  ]
 }


### PR DESCRIPTION
## Summary
- switch the shipped Is This Designer advancement to the pet stat threshold trigger keyed to ability max rank
- share a constant for the ability max rank stat name and value between runtime triggers and data generation so regenerated data stays in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db55ee3ac8832f8558c530ff08fe0f