### PR TITLE
ability refinements

### DIFF
--- a/src/main/java/woflo/petsplus/api/registry/OwnerBrokeBlockTriggerFactory.java
+++ b/src/main/java/woflo/petsplus/api/registry/OwnerBrokeBlockTriggerFactory.java
@@ -1,0 +1,97 @@
+package woflo.petsplus.api.registry;
+
+import net.minecraft.util.Identifier;
+import woflo.petsplus.api.Trigger;
+import woflo.petsplus.api.TriggerContext;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+final class OwnerBrokeBlockTriggerFactory {
+
+    private OwnerBrokeBlockTriggerFactory() {
+    }
+
+    static Trigger create(Identifier triggerId, Optional<Boolean> requireValuable,
+                          Optional<Identifier> requiredBlockId, int cooldown) {
+        Objects.requireNonNull(triggerId, "triggerId");
+        Objects.requireNonNull(requireValuable, "requireValuable");
+        Objects.requireNonNull(requiredBlockId, "requiredBlockId");
+        return new Trigger() {
+            @Override
+            public Identifier getId() {
+                return triggerId;
+            }
+
+            @Override
+            public int getInternalCooldownTicks() {
+                return cooldown;
+            }
+
+            @Override
+            public boolean shouldActivate(TriggerContext context) {
+                String eventType = context.getEventType();
+                String expectedEvent = triggerId.getPath();
+                if (!Objects.equals(eventType, expectedEvent)
+                    && !Objects.equals(eventType, triggerId.toString())) {
+                    return false;
+                }
+                if (requiredBlockId.isPresent()
+                    && !matchesRequiredBlock(context, requiredBlockId.get())) {
+                    return false;
+                }
+                if (requireValuable.isEmpty()) {
+                    return true;
+                }
+                Boolean isValuable = context.getData("block_valuable", Boolean.class);
+                if (isValuable == null) {
+                    return false;
+                }
+                return isValuable.equals(requireValuable.get());
+            }
+        };
+    }
+
+    private static boolean matchesRequiredBlock(TriggerContext context, Identifier expected) {
+        Identifier payloadIdentifier = context.getData("block_identifier", Identifier.class);
+        if (identifiersEqualIgnoreCase(payloadIdentifier, expected)) {
+            return true;
+        }
+
+        String idString = context.getData("block_id", String.class);
+        if (stringMatchesIdentifier(idString, expected)) {
+            return true;
+        }
+
+        String noNamespace = context.getData("block_id_no_namespace", String.class);
+        return noNamespace != null && noNamespace.equalsIgnoreCase(expected.getPath());
+    }
+
+    private static boolean identifiersEqualIgnoreCase(@Nullable Identifier actual, Identifier expected) {
+        if (actual == null) {
+            return false;
+        }
+        if (actual.equals(expected)) {
+            return true;
+        }
+        return actual.getNamespace().equalsIgnoreCase(expected.getNamespace())
+            && actual.getPath().equalsIgnoreCase(expected.getPath());
+    }
+
+    private static boolean stringMatchesIdentifier(@Nullable String candidate, Identifier expected) {
+        if (candidate == null || candidate.isEmpty()) {
+            return false;
+        }
+        if (candidate.equalsIgnoreCase(expected.toString())) {
+            return true;
+        }
+        Identifier parsed = Identifier.tryParse(candidate.toLowerCase(Locale.ROOT));
+        if (identifiersEqualIgnoreCase(parsed, expected)) {
+            return true;
+        }
+        return candidate.equalsIgnoreCase(expected.getPath());
+    }
+}

--- a/src/main/java/woflo/petsplus/effects/HealOwnerFlatPctEffect.java
+++ b/src/main/java/woflo/petsplus/effects/HealOwnerFlatPctEffect.java
@@ -6,14 +6,16 @@ import woflo.petsplus.api.Effect;
 import woflo.petsplus.api.EffectContext;
 
 /**
- * Effect that heals the owner by a flat percentage of their max health.
+ * Effect that heals the owner by combining a flat amount with a percentage of their maximum health.
  */
 public class HealOwnerFlatPctEffect implements Effect {
     private static final Identifier ID = Identifier.of("petsplus", "heal_owner_flat_pct");
-    
+
+    private final double flatAmount;
     private final double healPercent;
-    
-    public HealOwnerFlatPctEffect(double healPercent) {
+
+    public HealOwnerFlatPctEffect(double flatAmount, double healPercent) {
+        this.flatAmount = flatAmount;
         this.healPercent = healPercent;
     }
     
@@ -25,17 +27,24 @@ public class HealOwnerFlatPctEffect implements Effect {
     @Override
     public boolean execute(EffectContext context) {
         PlayerEntity owner = context.getOwner();
-        
-        float maxHealth = owner.getMaxHealth();
-        float healAmount = (float) (maxHealth * healPercent);
-        
+
+        if (owner == null || !owner.isAlive() || owner.isRemoved()) {
+            return false;
+        }
+
+        float healAmount = calculateHealAmount(owner.getMaxHealth());
+
         owner.heal(healAmount);
-        
+
         return true;
     }
-    
+
     @Override
     public int getDurationTicks() {
         return 0; // Instant effect
+    }
+
+    float calculateHealAmount(float maxHealth) {
+        return (float) (flatAmount + (maxHealth * healPercent));
     }
 }

--- a/src/main/java/woflo/petsplus/effects/OwnerNextAttackBonusEffect.java
+++ b/src/main/java/woflo/petsplus/effects/OwnerNextAttackBonusEffect.java
@@ -2,6 +2,7 @@ package woflo.petsplus.effects;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import woflo.petsplus.api.Effect;
 import woflo.petsplus.api.EffectContext;
@@ -37,16 +38,29 @@ public class OwnerNextAttackBonusEffect implements Effect {
     @Override
     public boolean execute(EffectContext context) {
         PlayerEntity owner = context.getOwner();
+        if (owner == null || !owner.isAlive() || owner.isRemoved()) {
+            return false;
+        }
+
+        ServerWorld world = context.getWorld();
+        if (world == null) {
+            if (owner.getWorld() instanceof ServerWorld ownerWorld) {
+                world = ownerWorld;
+            } else {
+                return false;
+            }
+        }
+
         OwnerCombatState combatState = OwnerCombatState.getOrCreate(owner);
-        
+
         // Create attack rider data
         AttackRiderData riderData = new AttackRiderData(
             bonusDamagePct,
             vsTag,
             onHitEffect,
-            context.getWorld().getTime() + expireTicks
+            world.getTime() + expireTicks
         );
-        
+
         combatState.addNextAttackRider("damage_bonus", riderData);
         return true;
     }

--- a/src/main/resources/data/petsplus/abilities/bulwark_redirect.json
+++ b/src/main/resources/data/petsplus/abilities/bulwark_redirect.json
@@ -7,7 +7,7 @@
   "effects": [
     {
       "type": "projectile_dr_for_owner",
-      "reduction_pct": 0.25,
+      "percent": 0.25,
       "duration_ticks": 100,
       "radius": 8.0
     },

--- a/src/main/resources/data/petsplus/abilities/gale_pace.json
+++ b/src/main/resources/data/petsplus/abilities/gale_pace.json
@@ -2,7 +2,7 @@
   "id": "petsplus:gale_pace",
   "trigger": {
     "event": "owner_begin_fall",
-    "min_fall_distance": 2.0,
+    "min_fall": 2.0,
     "internal_cd_ticks": 120
   },
   "effects": [

--- a/src/main/resources/data/petsplus/abilities/mounted_cone_aura.json
+++ b/src/main/resources/data/petsplus/abilities/mounted_cone_aura.json
@@ -3,7 +3,7 @@
   "description": "Mounted support aura",
   "trigger": {
     "event": "interval_while_active",
-    "interval_ticks": 40,
+    "ticks": 40,
     "internal_cd_ticks": 40
   },
   "effects": [

--- a/src/main/resources/data/petsplus/abilities/mounted_extra_rolls.json
+++ b/src/main/resources/data/petsplus/abilities/mounted_extra_rolls.json
@@ -2,7 +2,7 @@
   "id": "petsplus:mounted_extra_rolls",
   "trigger": {
     "event": "owner_begin_fall",
-    "require_mounted": true,
+    "require_mounted_owner": true,
     "internal_cd_ticks": 80
   },
   "effects": [

--- a/src/main/resources/data/petsplus/abilities/nap_time_radius.json
+++ b/src/main/resources/data/petsplus/abilities/nap_time_radius.json
@@ -2,7 +2,7 @@
   "id": "petsplus:nap_time_radius",
   "trigger": {
     "event": "interval_while_active",
-    "interval_ticks": 400,
+    "ticks": 400,
     "internal_cd_ticks": 400
   },
   "effects": [

--- a/src/main/resources/data/petsplus/abilities/perched_haste_bonus.json
+++ b/src/main/resources/data/petsplus/abilities/perched_haste_bonus.json
@@ -2,7 +2,7 @@
   "id": "petsplus:perched_haste_bonus",
   "trigger": {
     "event": "interval_while_active",
-    "interval_ticks": 200,
+    "ticks": 200,
     "internal_cd_ticks": 200
   },
   "effects": [

--- a/src/main/resources/data/petsplus/abilities/windlash_rider.json
+++ b/src/main/resources/data/petsplus/abilities/windlash_rider.json
@@ -2,7 +2,7 @@
   "id": "petsplus:windlash_rider",
   "trigger": {
     "event": "owner_begin_fall",
-    "min_fall_distance": 3.0,
+    "min_fall": 3.0,
     "internal_cd_ticks": 120
   },
   "effects": [

--- a/src/test/java/net/minecraft/block/AbstractBlock.java
+++ b/src/test/java/net/minecraft/block/AbstractBlock.java
@@ -1,0 +1,13 @@
+package net.minecraft.block;
+
+/** Minimal AbstractBlock stub for tests. */
+public class AbstractBlock {
+    protected AbstractBlock(Settings settings) {
+    }
+
+    public static class Settings {
+        public static Settings create() {
+            return new Settings();
+        }
+    }
+}

--- a/src/test/java/net/minecraft/block/Block.java
+++ b/src/test/java/net/minecraft/block/Block.java
@@ -1,0 +1,8 @@
+package net.minecraft.block;
+
+/** Minimal block stub for tests. */
+public class Block extends AbstractBlock {
+    public Block() {
+        super(new Settings());
+    }
+}

--- a/src/test/java/net/minecraft/block/BlockState.java
+++ b/src/test/java/net/minecraft/block/BlockState.java
@@ -1,0 +1,18 @@
+package net.minecraft.block;
+
+import net.minecraft.registry.tag.TagKey;
+
+/** Minimal block state stub for tests. */
+public class BlockState {
+    public boolean isOf(Block block) {
+        return false;
+    }
+
+    public boolean isIn(TagKey<Block> tag) {
+        return false;
+    }
+
+    public Block getBlock() {
+        return null;
+    }
+}

--- a/src/test/java/net/minecraft/block/Blocks.java
+++ b/src/test/java/net/minecraft/block/Blocks.java
@@ -1,0 +1,14 @@
+package net.minecraft.block;
+
+/** Minimal Blocks stub for tests to avoid loading real registry. */
+public final class Blocks {
+    public static final Block ANCIENT_DEBRIS = new Block();
+    public static final Block NETHERITE_BLOCK = new Block();
+    public static final Block AMETHYST_CLUSTER = new Block();
+    public static final Block BUDDING_AMETHYST = new Block();
+    public static final Block REINFORCED_DEEPSLATE = new Block();
+    public static final Block BEACON = new Block();
+
+    private Blocks() {
+    }
+}

--- a/src/test/java/net/minecraft/entity/Entity.java
+++ b/src/test/java/net/minecraft/entity/Entity.java
@@ -15,6 +15,7 @@ public class Entity {
     protected double y;
     protected double z;
     private boolean removed;
+    public double fallDistance;
     private Text displayName = Text.literal("Entity");
 
     public Entity(World world) {

--- a/src/test/java/net/minecraft/entity/LivingEntity.java
+++ b/src/test/java/net/minecraft/entity/LivingEntity.java
@@ -26,4 +26,8 @@ public class LivingEntity extends Entity {
     public void setMaxHealth(float maxHealth) {
         this.maxHealth = maxHealth;
     }
+
+    public net.minecraft.entity.EntityType<?> getType() {
+        return null;
+    }
 }

--- a/src/test/java/net/minecraft/entity/player/PlayerEntity.java
+++ b/src/test/java/net/minecraft/entity/player/PlayerEntity.java
@@ -1,6 +1,7 @@
 package net.minecraft.entity.player;
 
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
@@ -31,5 +32,9 @@ public class PlayerEntity extends LivingEntity {
 
     public float getAttackCooldownProgress(float partialTicks) {
         return 1.0f;
+    }
+
+    public Text getName() {
+        return Text.literal("Player");
     }
 }

--- a/src/test/java/net/minecraft/entity/projectile/PersistentProjectileEntity.java
+++ b/src/test/java/net/minecraft/entity/projectile/PersistentProjectileEntity.java
@@ -1,0 +1,25 @@
+package net.minecraft.entity.projectile;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+
+/** Minimal persistent projectile stub for tests. */
+public class PersistentProjectileEntity extends Entity {
+    private boolean critical;
+
+    public PersistentProjectileEntity(World world) {
+        super(world);
+    }
+
+    public net.minecraft.entity.EntityType<?> getType() {
+        return null;
+    }
+
+    public boolean isCritical() {
+        return critical;
+    }
+
+    public void setCritical(boolean critical) {
+        this.critical = critical;
+    }
+}

--- a/src/test/java/net/minecraft/registry/RegistryKey.java
+++ b/src/test/java/net/minecraft/registry/RegistryKey.java
@@ -18,6 +18,10 @@ public final class RegistryKey<T> {
         return new RegistryKey<>(id);
     }
 
+    public static <T> RegistryKey<T> of(RegistryKey<? extends Registry<T>> registry, Identifier id) {
+        return new RegistryKey<>(id);
+    }
+
     public Identifier getValue() {
         return value;
     }

--- a/src/test/java/net/minecraft/registry/tag/BlockTags.java
+++ b/src/test/java/net/minecraft/registry/tag/BlockTags.java
@@ -1,0 +1,23 @@
+package net.minecraft.registry.tag;
+
+import net.minecraft.block.Block;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+
+public final class BlockTags {
+    public static final TagKey<Block> DIAMOND_ORES = create("diamond_ores");
+    public static final TagKey<Block> EMERALD_ORES = create("emerald_ores");
+    public static final TagKey<Block> GOLD_ORES = create("gold_ores");
+    public static final TagKey<Block> LAPIS_ORES = create("lapis_ores");
+    public static final TagKey<Block> REDSTONE_ORES = create("redstone_ores");
+    public static final TagKey<Block> COAL_ORES = create("coal_ores");
+    public static final TagKey<Block> COPPER_ORES = create("copper_ores");
+    public static final TagKey<Block> IRON_ORES = create("iron_ores");
+    public static final TagKey<Block> BEACON_BASE_BLOCKS = create("beacon_base_blocks");
+
+    private BlockTags() {}
+
+    private static TagKey<Block> create(String path) {
+        return TagKey.of(RegistryKeys.BLOCK, Identifier.of("minecraft", path));
+    }
+}

--- a/src/test/java/net/minecraft/text/Text.java
+++ b/src/test/java/net/minecraft/text/Text.java
@@ -4,6 +4,10 @@ package net.minecraft.text;
 public interface Text {
     String asString();
 
+    default String getString() {
+        return asString();
+    }
+
     static MutableText literal(String literal) {
         return new MutableText(literal);
     }

--- a/src/test/java/net/minecraft/util/Identifier.java
+++ b/src/test/java/net/minecraft/util/Identifier.java
@@ -18,6 +18,29 @@ public final class Identifier {
         return new Identifier("minecraft", path);
     }
 
+    public static Identifier tryParse(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        int colonIndex = trimmed.indexOf(':');
+        if (colonIndex < 0) {
+            return new Identifier("minecraft", trimmed);
+        }
+        if (colonIndex == 0 || colonIndex == trimmed.length() - 1) {
+            return null;
+        }
+        String namespace = trimmed.substring(0, colonIndex);
+        String path = trimmed.substring(colonIndex + 1);
+        if (namespace.isEmpty() || path.isEmpty()) {
+            return null;
+        }
+        return new Identifier(namespace, path);
+    }
+
     public String getNamespace() {
         return namespace;
     }

--- a/src/test/java/net/minecraft/world/World.java
+++ b/src/test/java/net/minecraft/world/World.java
@@ -22,4 +22,8 @@ public class World {
     public void setTime(long time) {
         this.time = time;
     }
+
+    public boolean isClient() {
+        return false;
+    }
 }

--- a/src/test/java/woflo/petsplus/api/registry/OwnerBrokeBlockTriggerTest.java
+++ b/src/test/java/woflo/petsplus/api/registry/OwnerBrokeBlockTriggerTest.java
@@ -1,0 +1,101 @@
+package woflo.petsplus.api.registry;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+import org.junit.jupiter.api.Test;
+import woflo.petsplus.api.Trigger;
+import woflo.petsplus.api.TriggerContext;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OwnerBrokeBlockTriggerTest {
+
+    @Test
+    void blockIdFilterMatchesNamespacedIdentifier() {
+        Trigger trigger = createTrigger(Optional.empty(), Optional.of(parseIdentifier("minecraft:diamond_ore")));
+        TriggerContext context = createContext("minecraft:diamond_ore", true, true);
+        assertTrue(trigger.shouldActivate(context), "Trigger should activate when block identifiers match");
+    }
+
+    @Test
+    void blockIdFilterMatchesNamespaceFreePayload() {
+        Trigger trigger = createTrigger(Optional.empty(), Optional.of(parseIdentifier("minecraft:diamond_ore")));
+        TriggerContext context = createContext(null, false, true);
+        context.withData("block_id_no_namespace", "diamond_ore");
+        assertTrue(trigger.shouldActivate(context), "Trigger should accept namespace-free block identifiers");
+    }
+
+    @Test
+    void blockIdFilterRejectsMismatchedPayload() {
+        Trigger trigger = createTrigger(Optional.empty(), Optional.of(parseIdentifier("minecraft:diamond_ore")));
+        TriggerContext context = createContext("minecraft:gold_ore", true, true);
+        assertFalse(trigger.shouldActivate(context), "Trigger should reject non-matching block identifiers");
+    }
+
+    @Test
+    void blockValuableRequirementRespected() {
+        Trigger trigger = createTrigger(Optional.of(Boolean.TRUE), Optional.of(parseIdentifier("minecraft:diamond_ore")));
+
+        TriggerContext matchingContext = createContext("minecraft:diamond_ore", true, true);
+        assertTrue(trigger.shouldActivate(matchingContext), "Trigger should activate when block is valuable and matches id");
+
+        TriggerContext nonValuable = createContext("minecraft:diamond_ore", true, false);
+        assertFalse(trigger.shouldActivate(nonValuable), "Trigger should not activate when valuable requirement fails");
+    }
+
+    @Test
+    void blockIdFilterMatchesCaseInsensitiveStrings() {
+        Trigger trigger = createTrigger(Optional.empty(), Optional.of(parseIdentifier("minecraft:diamond_ore")));
+        TriggerContext context = createContext("MINECRAFT:DIAMOND_ORE", false, true);
+        assertTrue(trigger.shouldActivate(context), "Identifier comparison should ignore case differences");
+    }
+
+    @Test
+    void eventTypeAllowsNamespacedTrigger() {
+        Trigger trigger = createTrigger(Optional.empty(), Optional.empty());
+        TriggerContext context = createContext("minecraft:stone", false, false, "petsplus:owner_broke_block");
+        context.withData("block_id_no_namespace", "stone");
+        assertTrue(trigger.shouldActivate(context), "Namespaced event identifiers should still activate");
+    }
+
+    private static TriggerContext createContext(String blockId, boolean includeIdentifier, boolean blockValuable) {
+        return createContext(blockId, includeIdentifier, blockValuable, "owner_broke_block");
+    }
+
+    private static TriggerContext createContext(String blockId, boolean includeIdentifier, boolean blockValuable, String eventType) {
+        MinecraftServer server = new MinecraftServer();
+        ServerWorld world = new ServerWorld(server);
+        ServerPlayerEntity owner = new ServerPlayerEntity(world);
+        TriggerContext context = new TriggerContext(world, null, owner, eventType);
+        if (blockId != null) {
+            context.withData("block_id", blockId);
+            if (includeIdentifier) {
+                Identifier identifier = parseIdentifier(blockId);
+                context.withData("block_identifier", identifier);
+                context.withData("block_id_no_namespace", identifier.getPath());
+            }
+        }
+        context.withData("block_valuable", blockValuable);
+        return context;
+    }
+
+    private static Identifier parseIdentifier(String blockId) {
+        int colonIndex = blockId.indexOf(':');
+        if (colonIndex >= 0) {
+            String namespace = blockId.substring(0, colonIndex);
+            String path = blockId.substring(colonIndex + 1);
+            return Identifier.of(namespace, path);
+        }
+        return Identifier.of("minecraft", blockId);
+    }
+
+    private static Trigger createTrigger(Optional<Boolean> requireValuable, Optional<Identifier> requiredBlockId) {
+        Identifier triggerId = Identifier.of("petsplus", "owner_broke_block");
+        return OwnerBrokeBlockTriggerFactory.create(triggerId, requireValuable, requiredBlockId, 0);
+    }
+}

--- a/src/test/java/woflo/petsplus/data/AbilityTriggerRegistrationTest.java
+++ b/src/test/java/woflo/petsplus/data/AbilityTriggerRegistrationTest.java
@@ -1,0 +1,88 @@
+package woflo.petsplus.data;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbilityTriggerRegistrationTest {
+
+    @Test
+    void edgeStepAbilityUsesNewFallDamageTriggerId() throws IOException {
+        JsonObject trigger = loadAbilityTrigger("edge_step.json");
+        assertEquals("owner_took_fall_damage", trigger.get("event").getAsString());
+    }
+
+    @Test
+    void projectileLevitationAbilityUsesProjectileTriggerId() throws IOException {
+        JsonObject trigger = loadAbilityTrigger("projectile_levitation.json");
+        assertEquals("owner_shot_projectile", trigger.get("event").getAsString());
+    }
+
+    @Test
+    void spotterFallbackAbilityUsesBlockBreakTriggerId() throws IOException {
+        JsonObject trigger = loadAbilityTrigger("spotter_fallback.json");
+        assertEquals("owner_broke_block", trigger.get("event").getAsString());
+    }
+
+    @Test
+    void ownerBeginFallAbilitiesUseNewMinFallField() throws IOException {
+        JsonObject windlashTrigger = loadAbilityTrigger("windlash_rider.json");
+        assertTrue(windlashTrigger.has("min_fall"), "Windlash Rider trigger should define min_fall");
+        assertEquals(3.0, windlashTrigger.get("min_fall").getAsDouble());
+
+        JsonObject galePaceTrigger = loadAbilityTrigger("gale_pace.json");
+        assertTrue(galePaceTrigger.has("min_fall"), "Gale Pace trigger should define min_fall");
+        assertEquals(2.0, galePaceTrigger.get("min_fall").getAsDouble());
+    }
+
+    @Test
+    void mountedExtraRollsRequiresMountedOwnerKey() throws IOException {
+        JsonObject trigger = loadAbilityTrigger("mounted_extra_rolls.json");
+        assertTrue(trigger.has("require_mounted_owner"), "Mounted Extra Rolls should require mounted owner");
+        assertEquals(true, trigger.get("require_mounted_owner").getAsBoolean());
+    }
+
+    @Test
+    void bulwarkRedirectUsesPercentFieldForProjectileDr() throws IOException {
+        JsonObject ability = loadAbilityJson("bulwark_redirect.json");
+        JsonArray effects = ability.getAsJsonArray("effects");
+        assertNotNull(effects, "Bulwark Redirect should define effects");
+        JsonObject drEffect = null;
+        for (int i = 0; i < effects.size(); i++) {
+            JsonObject effect = effects.get(i).getAsJsonObject();
+            if ("projectile_dr_for_owner".equals(effect.get("type").getAsString())) {
+                drEffect = effect;
+                break;
+            }
+        }
+
+        assertNotNull(drEffect, "Bulwark Redirect should include projectile DR effect");
+        assertTrue(drEffect.has("percent"), "Projectile DR effect should use percent field");
+        assertEquals(0.25, drEffect.get("percent").getAsDouble(), 1.0E-6);
+    }
+
+    private static JsonObject loadAbilityTrigger(String fileName) throws IOException {
+        JsonObject json = loadAbilityJson(fileName);
+        JsonObject trigger = json.getAsJsonObject("trigger");
+        assertNotNull(trigger, "Ability JSON should contain a trigger object");
+        assertNotNull(trigger.get("event"), "Ability trigger must define an event");
+        return trigger;
+    }
+
+    private static JsonObject loadAbilityJson(String fileName) throws IOException {
+        Path path = Path.of("src", "main", "resources", "data", "petsplus", "abilities", fileName);
+        try (Reader reader = Files.newBufferedReader(path)) {
+            return JsonParser.parseReader(reader).getAsJsonObject();
+        }
+    }
+}

--- a/src/test/java/woflo/petsplus/effects/HealOwnerFlatPctEffectTest.java
+++ b/src/test/java/woflo/petsplus/effects/HealOwnerFlatPctEffectTest.java
@@ -1,0 +1,33 @@
+package woflo.petsplus.effects;
+
+import org.junit.jupiter.api.Test;
+import woflo.petsplus.api.EffectContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+class HealOwnerFlatPctEffectTest {
+
+    @Test
+    void executeReturnsFalseWhenOwnerMissing() {
+        EffectContext context = mock(EffectContext.class);
+        when(context.getOwner()).thenReturn(null);
+
+        HealOwnerFlatPctEffect effect = new HealOwnerFlatPctEffect(0.0, 0.25);
+
+        boolean result = effect.execute(context);
+
+        assertFalse(result, "Effect should not execute when owner is missing");
+        verify(context).getOwner();
+    }
+
+    @Test
+    void calculateHealAmountCombinesFlatAndPercent() {
+        HealOwnerFlatPctEffect effect = new HealOwnerFlatPctEffect(3.0, 0.1);
+
+        assertEquals(5.0f, effect.calculateHealAmount(20.0f), 1.0e-4f,
+            "Heal amount should include flat and percent components");
+    }
+}

--- a/src/test/java/woflo/petsplus/effects/OwnerNextAttackBonusEffectTest.java
+++ b/src/test/java/woflo/petsplus/effects/OwnerNextAttackBonusEffectTest.java
@@ -1,0 +1,61 @@
+package woflo.petsplus.effects;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import woflo.petsplus.api.EffectContext;
+import woflo.petsplus.state.OwnerCombatState;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OwnerNextAttackBonusEffectTest {
+
+    @Test
+    void executeReturnsFalseWhenOwnerMissing() {
+        EffectContext context = mock(EffectContext.class);
+        when(context.getOwner()).thenReturn(null);
+
+        OwnerNextAttackBonusEffect effect = new OwnerNextAttackBonusEffect(0.25);
+
+        boolean result = effect.execute(context);
+
+        assertFalse(result, "Effect should not execute when owner is missing");
+        verify(context).getOwner();
+        verify(context, never()).getWorld();
+    }
+
+    @Test
+    void executeFallsBackToOwnerWorldWhenContextMissing() {
+        EffectContext context = mock(EffectContext.class);
+        PlayerEntity owner = mock(PlayerEntity.class);
+        ServerWorld ownerWorld = mock(ServerWorld.class);
+        OwnerCombatState combatState = mock(OwnerCombatState.class);
+
+        when(context.getOwner()).thenReturn(owner);
+        when(context.getWorld()).thenReturn(null);
+        when(owner.isAlive()).thenReturn(true);
+        when(owner.isRemoved()).thenReturn(false);
+        when(owner.getWorld()).thenReturn(ownerWorld);
+        when(ownerWorld.getTime()).thenReturn(80L);
+
+        try (MockedStatic<OwnerCombatState> ownerStateStatic = mockStatic(OwnerCombatState.class)) {
+            ownerStateStatic.when(() -> OwnerCombatState.getOrCreate(owner)).thenReturn(combatState);
+
+            OwnerNextAttackBonusEffect effect = new OwnerNextAttackBonusEffect(0.25);
+            boolean result = effect.execute(context);
+
+            assertTrue(result, "Effect should fallback to the owner's world when context world missing");
+            verify(owner).getWorld();
+            verify(combatState).addNextAttackRider(eq("damage_bonus"), any());
+        }
+    }
+}

--- a/src/test/java/woflo/petsplus/effects/ProjectileDrForOwnerEffectTest.java
+++ b/src/test/java/woflo/petsplus/effects/ProjectileDrForOwnerEffectTest.java
@@ -1,0 +1,86 @@
+package woflo.petsplus.effects;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import woflo.petsplus.api.EffectContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProjectileDrForOwnerEffectTest {
+
+    @BeforeEach
+    void resetActiveDr() {
+        ProjectileDrForOwnerEffect.cleanupExpired(Long.MAX_VALUE);
+    }
+
+    @Test
+    void executeReturnsFalseWhenOwnerMissing() {
+        EffectContext context = mock(EffectContext.class);
+        when(context.getOwner()).thenReturn(null);
+
+        ProjectileDrForOwnerEffect effect = new ProjectileDrForOwnerEffect(0.25, 40);
+
+        boolean result = effect.execute(context);
+
+        assertFalse(result, "Effect should not execute when owner is missing");
+        verify(context).getOwner();
+        verify(context, never()).getWorld();
+    }
+
+    @Test
+    void getProjectileDrClearsRemovedOwner() {
+        ProjectileDrForOwnerEffect effect = new ProjectileDrForOwnerEffect(0.5, 60);
+        EffectContext context = mock(EffectContext.class);
+        PlayerEntity owner = mock(PlayerEntity.class);
+        ServerWorld world = mock(ServerWorld.class);
+
+        when(context.getOwner()).thenReturn(owner);
+        when(context.getWorld()).thenReturn(world);
+        when(owner.isRemoved()).thenReturn(false);
+        when(owner.isAlive()).thenReturn(true);
+        when(world.getTime()).thenReturn(100L);
+
+        boolean applied = effect.execute(context);
+        assertTrue(applied, "Effect should apply when owner is valid");
+
+        when(owner.isRemoved()).thenReturn(true);
+
+        double damageReduction = ProjectileDrForOwnerEffect.getProjectileDr(owner);
+
+        assertEquals(0.0, damageReduction, 0.0001, "Damage reduction should be cleared for removed owners");
+
+        double subsequent = ProjectileDrForOwnerEffect.getProjectileDr(owner);
+        assertEquals(0.0, subsequent, 0.0001, "Removed owners should stay absent from the cache");
+
+        verify(world).getTime();
+    }
+
+    @Test
+    void executeFallsBackToOwnerWorldWhenContextMissing() {
+        ProjectileDrForOwnerEffect effect = new ProjectileDrForOwnerEffect(0.5, 60);
+        EffectContext context = mock(EffectContext.class);
+        PlayerEntity owner = mock(PlayerEntity.class);
+        ServerWorld world = mock(ServerWorld.class);
+
+        when(context.getOwner()).thenReturn(owner);
+        when(context.getWorld()).thenReturn(null);
+        when(owner.isRemoved()).thenReturn(false);
+        when(owner.isAlive()).thenReturn(true);
+        when(owner.getWorld()).thenReturn(world);
+        when(world.getTime()).thenReturn(200L);
+
+        boolean applied = effect.execute(context);
+
+        assertTrue(applied, "Effect should resolve owner world when context world missing");
+        verify(owner).getWorld();
+        verify(world).getTime();
+    }
+}

--- a/src/test/java/woflo/petsplus/effects/TagTargetEffectTest.java
+++ b/src/test/java/woflo/petsplus/effects/TagTargetEffectTest.java
@@ -1,0 +1,86 @@
+package woflo.petsplus.effects;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import woflo.petsplus.api.EffectContext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TagTargetEffectTest {
+
+    @BeforeEach
+    void clearTags() {
+        TagTargetEffect.cleanupExpiredTags(Long.MAX_VALUE);
+    }
+
+    @Test
+    void executeReturnsFalseWhenTriggerContextMissing() {
+        EffectContext context = mock(EffectContext.class);
+
+        when(context.getData("target", Entity.class)).thenReturn(null);
+        when(context.getTriggerContext()).thenReturn(null);
+        when(context.getTarget()).thenReturn(null);
+
+        TagTargetEffect effect = new TagTargetEffect("target", "petsplus:test", 40);
+
+        boolean result = effect.execute(context);
+
+        assertFalse(result, "Effect should not execute without a target or trigger context");
+        verify(context).getData("target", Entity.class);
+        verify(context).getTriggerContext();
+        verify(context).getTarget();
+        verify(context, never()).getWorld();
+    }
+
+    @Test
+    void executeUsesStoredTargetWhenTriggerContextMissing() {
+        EffectContext context = mock(EffectContext.class);
+        Entity storedTarget = mock(Entity.class);
+        ServerWorld world = mock(ServerWorld.class);
+
+        when(context.getData("target", Entity.class)).thenReturn(null);
+        when(context.getTriggerContext()).thenReturn(null);
+        when(context.getTarget()).thenReturn(storedTarget);
+        when(context.getWorld()).thenReturn(world);
+        when(storedTarget.getWorld()).thenReturn(world);
+        when(world.getTime()).thenReturn(100L);
+
+        TagTargetEffect effect = new TagTargetEffect("target", "petsplus:test", 40);
+
+        boolean result = effect.execute(context);
+
+        assertTrue(result, "Effect should execute when a stored target is available");
+        assertTrue(TagTargetEffect.hasTag(storedTarget, "petsplus:test"), "Stored target should be tagged");
+
+        TagTargetEffect.removeTag(storedTarget, "petsplus:test");
+        verify(context).getWorld();
+    }
+
+    @Test
+    void executeFallsBackToTargetWorld() {
+        EffectContext context = mock(EffectContext.class);
+        Entity target = mock(Entity.class);
+        ServerWorld world = mock(ServerWorld.class);
+
+        when(context.getData("target", Entity.class)).thenReturn(target);
+        when(context.getWorld()).thenReturn(null);
+        when(target.getWorld()).thenReturn(world);
+        when(world.getTime()).thenReturn(150L);
+
+        TagTargetEffect effect = new TagTargetEffect("target", "petsplus:test", 20);
+
+        boolean result = effect.execute(context);
+
+        assertTrue(result, "Effect should use the target world when context world is unavailable");
+        assertTrue(TagTargetEffect.hasTag(target, "petsplus:test"), "Target should receive tag using fallback world");
+
+        TagTargetEffect.removeTag(target, "petsplus:test");
+    }
+}

--- a/src/test/java/woflo/petsplus/events/CombatEventHandlerTest.java
+++ b/src/test/java/woflo/petsplus/events/CombatEventHandlerTest.java
@@ -1,0 +1,223 @@
+package woflo.petsplus.events;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.damage.DamageTypes;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.Identifier;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import woflo.petsplus.api.TriggerContext;
+import woflo.petsplus.state.OwnerCombatState;
+import woflo.petsplus.state.PetSwarmIndex;
+import woflo.petsplus.state.StateManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class CombatEventHandlerTest {
+
+    @Test
+    void ownerFallDamageDispatchesAbilityPayload() throws Exception {
+        MinecraftServer server = new MinecraftServer();
+        ServerWorld world = new ServerWorld(server);
+        world.setTime(200L);
+        ServerPlayerEntity owner = new ServerPlayerEntity(world);
+        owner.setMaxHealth(20f);
+        owner.setHealth(20f);
+        owner.fallDistance = 6.5f;
+
+        StateManager stateManager = mock(StateManager.class);
+        PetSwarmIndex swarmIndex = mock(PetSwarmIndex.class);
+        when(stateManager.getSwarmIndex()).thenReturn(swarmIndex);
+        lenient().when(swarmIndex.snapshotOwner(any())).thenReturn(List.of());
+        OwnerCombatState ownerState = new OwnerCombatState(owner);
+        when(stateManager.getOwnerState(owner)).thenReturn(ownerState);
+
+        List<String> events = new ArrayList<>();
+        List<Map<String, Object>> payloads = new ArrayList<>();
+        doAnswer(invocation -> {
+            events.add(invocation.getArgument(1));
+            payloads.add(invocation.getArgument(2));
+            return null;
+        }).when(stateManager).dispatchAbilityTrigger(any(ServerPlayerEntity.class), any(String.class), any());
+
+        try (MockedStatic<StateManager> stateManagerStatic = mockStatic(StateManager.class)) {
+            stateManagerStatic.when(() -> StateManager.forWorld(world)).thenReturn(stateManager);
+
+            DamageSource fallDamage = mock(DamageSource.class);
+            when(fallDamage.isOf(DamageTypes.FALL)).thenReturn(true);
+            lenient().when(fallDamage.getAttacker()).thenReturn(null);
+            lenient().when(fallDamage.getSource()).thenReturn(null);
+
+            invokeHandleOwnerDamageReceived(owner, fallDamage, 3.5f);
+        }
+
+        int idx = events.indexOf("owner_took_fall_damage");
+        assertTrue(idx >= 0, "Expected owner_took_fall_damage trigger");
+        Map<String, Object> payload = payloads.get(idx);
+        assertNotNull(payload, "Fall damage payload should not be null");
+        assertEquals(3.5d, (double) payload.get("damage"), 1.0e-4, "Damage amount should match event");
+        assertEquals(6.5d, (double) payload.get("fall_distance"), 1.0e-4, "Fall distance should be recorded");
+    }
+
+    @Test
+    void projectileDamageEmitsOwnerShotProjectile() throws Exception {
+        MinecraftServer server = new MinecraftServer();
+        ServerWorld world = new ServerWorld(server);
+        world.setTime(120L);
+        ServerPlayerEntity owner = new ServerPlayerEntity(world);
+        owner.setMaxHealth(20f);
+        owner.setHealth(18f);
+
+        LivingEntity target = new LivingEntity(world);
+        target.setMaxHealth(30f);
+        target.setHealth(30f);
+
+        StateManager stateManager = mock(StateManager.class);
+        PetSwarmIndex swarmIndex = mock(PetSwarmIndex.class);
+        when(stateManager.getSwarmIndex()).thenReturn(swarmIndex);
+        lenient().when(swarmIndex.snapshotOwner(any())).thenReturn(List.of());
+        OwnerCombatState ownerState = new OwnerCombatState(owner);
+        when(stateManager.getOwnerState(owner)).thenReturn(ownerState);
+
+        List<String> events = new ArrayList<>();
+        List<Map<String, Object>> payloads = new ArrayList<>();
+        doAnswer(invocation -> {
+            events.add(invocation.getArgument(1));
+            payloads.add(invocation.getArgument(2));
+            return null;
+        }).when(stateManager).dispatchAbilityTrigger(any(ServerPlayerEntity.class), any(String.class), any());
+
+        PersistentProjectileEntity projectile = new PersistentProjectileEntity(world);
+        projectile.setCritical(false);
+
+        try (MockedStatic<StateManager> stateManagerStatic = mockStatic(StateManager.class)) {
+            stateManagerStatic.when(() -> StateManager.forWorld(world)).thenReturn(stateManager);
+            invokeHandleProjectileDamage(owner, target, 4.0f, projectile);
+        }
+
+        int idx = events.indexOf("owner_shot_projectile");
+        assertTrue(idx >= 0, "Expected owner_shot_projectile trigger");
+        Map<String, Object> payload = payloads.get(idx);
+        assertNotNull(payload, "Projectile payload should not be null");
+        assertEquals(Boolean.FALSE, payload.get("projectile_critical"), "Payload should reflect non-critical shot");
+        assertEquals(payload.get("projectile_type"), payload.get("projectile_type_id"),
+            "Projectile type and id strings should match");
+        assertEquals(payload.get("projectile_type"), payload.get("projectile_id"),
+            "Legacy projectile_id should mirror type string");
+        assertEquals(projectile, payload.get("projectile_entity"), "Projectile entity should be forwarded");
+        assertEquals(target, payload.get("victim"), "Victim entity should be included in payload");
+        assertEquals(4.0d, (double) payload.get("damage"), 1.0e-4, "Damage should be captured in payload");
+
+        TriggerContext context = new TriggerContext(world, null, owner, "owner_shot_projectile");
+        for (Map.Entry<String, Object> entry : payload.entrySet()) {
+            context.withData(entry.getKey(), entry.getValue());
+        }
+        assertEquals(target, context.getVictim(), "Trigger context should expose projectile victim");
+        assertEquals(4.0d, context.getDamage(), 1.0e-4, "Trigger context should expose projectile damage");
+        assertFalse(ownerShotProjectileMatches(context, "arrow"),
+            "Unknown projectile type should not match arrow filter");
+    }
+
+    @Test
+    void populateProjectileMetadataProducesArrowIdentifier() {
+        Map<String, Object> payload = new java.util.HashMap<>();
+        Identifier arrowId = Identifier.of("minecraft", "arrow");
+        CombatEventHandler.populateProjectileMetadata(payload, arrowId, null);
+
+        assertEquals("minecraft:arrow", payload.get("projectile_type"), "Type string should use identifier value");
+        assertEquals("minecraft:arrow", payload.get("projectile_type_id"), "Type id should match identifier string");
+        assertEquals("minecraft:arrow", payload.get("projectile_id"), "Legacy projectile_id should mirror identifier");
+        assertEquals(arrowId, payload.get("projectile_identifier"), "Identifier instance should be stored");
+        assertEquals("arrow", payload.get("projectile_type_no_namespace"), "Namespace-stripped variant should be present");
+
+        MinecraftServer server = new MinecraftServer();
+        ServerWorld world = new ServerWorld(server);
+        ServerPlayerEntity owner = new ServerPlayerEntity(world);
+        TriggerContext context = new TriggerContext(world, null, owner, "owner_shot_projectile");
+        for (Map.Entry<String, Object> entry : payload.entrySet()) {
+            context.withData(entry.getKey(), entry.getValue());
+        }
+        boolean matches = ownerShotProjectileMatches(context, "arrow");
+        assertTrue(matches, () -> "OwnerShotProjectile trigger with projectile_type=arrow should activate, payload=" + payload);
+    }
+
+    @Test
+    void populateProjectileMetadataSanitizesRawStrings() {
+        Map<String, Object> payload = new java.util.HashMap<>();
+        CombatEventHandler.populateProjectileMetadata(payload, null, "EntityType[minecraft:egg]");
+
+        assertEquals("minecraft:egg", payload.get("projectile_type"), "Raw projectile strings should be sanitized");
+        assertEquals("egg", payload.get("projectile_type_no_namespace"), "Sanitized payload should expose stripped path");
+        assertEquals("minecraft:egg", payload.get("projectile_type_id"));
+        assertEquals("minecraft:egg", payload.get("projectile_id"));
+    }
+
+    private static void invokeHandleOwnerDamageReceived(PlayerEntity owner, DamageSource damageSource, float amount) throws Exception {
+        Method method = CombatEventHandler.class.getDeclaredMethod("handleOwnerDamageReceived", PlayerEntity.class, DamageSource.class, float.class);
+        method.setAccessible(true);
+        method.invoke(null, owner, damageSource, amount);
+    }
+
+    private static void invokeHandleProjectileDamage(PlayerEntity shooter, LivingEntity target, float damage, PersistentProjectileEntity projectile) throws Exception {
+        Method method = CombatEventHandler.class.getDeclaredMethod("handleProjectileDamage", PlayerEntity.class, LivingEntity.class, float.class, PersistentProjectileEntity.class);
+        method.setAccessible(true);
+        method.invoke(null, shooter, target, damage, projectile);
+    }
+
+    private static boolean ownerShotProjectileMatches(TriggerContext context, String filter) {
+        if (!"owner_shot_projectile".equals(context.getEventType())) {
+            return false;
+        }
+        String projectileType = context.getData("projectile_type", String.class);
+        if (projectileType == null) {
+            projectileType = context.getData("projectile_id", String.class);
+        }
+        if (projectileType == null) {
+            Identifier identifier = context.getData("projectile_identifier", Identifier.class);
+            projectileType = identifier != null ? identifier.toString() : null;
+        }
+        if (projectileType == null) {
+            projectileType = context.getData("projectile_type_no_namespace", String.class);
+            if (projectileType == null) {
+                return false;
+            }
+            projectileType = projectileType.toLowerCase(Locale.ROOT);
+            return filter.toLowerCase(Locale.ROOT).equals(projectileType);
+        }
+        projectileType = projectileType.toLowerCase(Locale.ROOT);
+        String normalizedFilter = filter.toLowerCase(Locale.ROOT);
+        if (normalizedFilter.equals(projectileType)) {
+            return true;
+        }
+        int colonIndex = projectileType.indexOf(':');
+        if (colonIndex >= 0 && colonIndex + 1 < projectileType.length()) {
+            String withoutNamespace = projectileType.substring(colonIndex + 1);
+            if (normalizedFilter.equals(withoutNamespace)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Summary
- sanitize projectile payload metadata and clamp owner health calculations to keep ability contexts stable
- allow owner_broke_block serializers to match namespaced events and case-insensitive block ids while updating the Identifier test stub
- let tagging and defensive effects fall back to owner/target worlds and expand regression coverage for the new behavior

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68db5607a4b0832fba6094bbc5a7aa07