### PR TITLE
Lighten leveling and roles documentation

### DIFF
--- a/docs/features/leveling.md
+++ b/docs/features/leveling.md
@@ -8,7 +8,9 @@ you earn spills outward, powering the abilities linked to their chosen
 
 If you earn XP, every nearby pet does too. Combat, mining, smelting,
 breeding, fishing, trading, advancements—if it fills your bar, it echoes
-through the pack as long as they’re close enough.
+through the pack as long as they’re close enough. Stack it with mood boosts
+from the [emotions loop](emotions.md) or smart [stimulus setups](stimulus.md)
+to keep everyone in motion.
 
 - **Range:** 32 blocks from you.
 - **Split:** XP divides evenly across owned pets inside that radius.
@@ -38,7 +40,8 @@ online quickly; late levels slow down to respect endgame toys.
 Each pet keeps tabs on what they were doing when XP rained in:
 
 - **Participation:** If they haven’t lifted a paw in five minutes, they
-  get a small penalty. Active helpers keep full credit.
+  get a small penalty. Active helpers keep full credit, especially when you
+  match their current [mood](moods.md) to the activity.
 - **Learning:** Their [nature](natures.md) and baked-in quirks tilt how
   fast they learn. Some are prodigies, some are professional nappers.
 
@@ -49,7 +52,8 @@ breakpoints—levels **3, 7, 12, 17, 23, and 27**—layer extra spice on top.
 Each [role](roles.md#role-rewards-and-breakpoints) carries its own
 `xpCurve`, so a Guardian’s grind may feel different from an Eepy Eeper’s
 nap-filled journey. Datapack makers can swap those numbers without
-touching code.
+touching code, letting you align progression with a pet’s [nature](natures.md)
+or pack story.
 
 ## Tribute Gates
 
@@ -85,7 +89,8 @@ specialization unlocks along the way.
 
 Want to remix progression? The global config adjusts how hard XP hits,
 while each role JSON controls scaling, tributes, and reward timing. Nudge
-a few numbers and you’ve got a whole new leveling story.
+a few numbers and you’ve got a whole new leveling story that still honors
+your preferred [design philosophy](design_philosophy.md).
 
 ## Death & Recovery
 
@@ -99,4 +104,5 @@ scratch.
 Server owners and modpack creators can redefine the whole loop through
 datapacks and configs—slow-burn RPG arcs, hyper-fast arenas, whatever
 fits your world. Every level should feel like a shared story between you
-and your companion.
+and your companion, especially when paired with customized [roles](roles.md)
+and mood-aware [emotions](emotions.md).

--- a/docs/features/roles.md
+++ b/docs/features/roles.md
@@ -12,10 +12,15 @@ abilities, and tributes reset.
   the pacing.
 - **They respect personality.** A Fierce pet plays Guardian differently
   than a Frisky one because [natures](natures.md) tilt stats and learning.
+  Pair that with the current [mood track](moods.md) to understand why a pet
+  leans in or taps out.
 - **They blend with moods.** A Striker in an [Angry mood](moods.md) goes
-  feral. A Support basking in **Bonded** doubles down on healing.
+  feral. A Support basking in **Bonded** doubles down on healing. Check the
+  [emotions overview](emotions.md) if you need a refresher on what those
+  feelings actually do.
 - **They’re remixable.** Everything lives in JSON, so adding or tweaking a
-  role is a datapack edit away.
+  role is a datapack edit away, especially once you’ve mapped out desired
+  [stimulus reactions](stimulus.md).
 
 ## Role Quick Reference
 
@@ -33,6 +38,9 @@ abilities, and tributes reset.
 
 Each role carries its own `xpCurve`, stat lean, and unlock list. What
 follows are the vibes, highlights, and why you’d bring each into a pack.
+If you’re sketching a new archetype, cross-reference the leveling
+[feature tiers](leveling.md#role-rewards-and-feature-levels) to keep the
+flow consistent.
 
 ## The Nine Roles
 
@@ -156,7 +164,8 @@ consumed—choose carefully.
 
 Mixing specializations multiplies options:
 
-- **Guardian + Support + Striker** covers defense, sustain, and burst.
+- **Guardian + Support + Striker** covers defense, sustain, and burst,
+  especially when moods are tuned for [party synergy](emotions.md#bonded).
 - **Scout + Eclipsed** hunts treasure and neutralizes threats before they
   reach you.
 - **Skyrider + Enchantment-Bound** keeps builders safe while accelerating
@@ -173,4 +182,5 @@ everything, so play the ensemble cast.
 - `xpCurve` defines tribute milestones and reward pacing.
 
 Refresh the datapack to hot-swap adjustments. No code changes required—just
-your imagination and a quick `/reload`.
+your imagination, a quick `/reload`, and the [design philosophy](design_philosophy.md)
+that defines your world.


### PR DESCRIPTION
## Summary
- soften the leveling overview language while trimming deep math details and clarifying tribute flow
- refresh the roles guide with tighter quick reference, condensed highlights, and simplified customization notes

## Testing
- not run (documentation updates only)


