### PR TITLE
Prune stale owner tasks when pets change owners

### DIFF
--- a/src/main/java/woflo/petsplus/component/PetsplusComponents.java
+++ b/src/main/java/woflo/petsplus/component/PetsplusComponents.java
@@ -64,6 +64,7 @@ public class PetsplusComponents {
         Optional<HistoryModule.Data> history,
         Optional<InventoryModule.Data> inventories,
         Optional<OwnerModule.Data> owner,
+        Optional<RelationshipModule.Data> relationships,
         Optional<SchedulingModule.Data> scheduling,
         Optional<CharacteristicsModule.Data> characteristics,
         Optional<PetGossipLedger> gossip,
@@ -84,6 +85,7 @@ public class PetsplusComponents {
                 HistoryModule.Data.CODEC.optionalFieldOf("history").forGetter(PetData::history),
                 InventoryModule.Data.CODEC.optionalFieldOf("inventories").forGetter(PetData::inventories),
                 OwnerModule.Data.CODEC.optionalFieldOf("owner").forGetter(PetData::owner),
+                RelationshipModule.Data.CODEC.optionalFieldOf("relationships").forGetter(PetData::relationships),
                 SchedulingModule.Data.CODEC.optionalFieldOf("scheduling").forGetter(PetData::scheduling),
                 CharacteristicsModule.Data.CODEC.optionalFieldOf("characteristics").forGetter(PetData::characteristics),
                 PetGossipLedger.CODEC.optionalFieldOf("gossipLedger").forGetter(PetData::gossip),
@@ -101,6 +103,8 @@ public class PetsplusComponents {
             nbtBackedPacketCodec(InventoryModule.Data.CODEC, "inventory module");
         private static final PacketCodec<RegistryByteBuf, OwnerModule.Data> OWNER_PACKET_CODEC =
             nbtBackedPacketCodec(OwnerModule.Data.CODEC, "owner module");
+        private static final PacketCodec<RegistryByteBuf, RelationshipModule.Data> RELATIONSHIP_PACKET_CODEC =
+            nbtBackedPacketCodec(RelationshipModule.Data.CODEC, "relationship module");
         private static final PacketCodec<RegistryByteBuf, SchedulingModule.Data> SCHEDULING_PACKET_CODEC =
             nbtBackedPacketCodec(SchedulingModule.Data.CODEC, "scheduling module");
         private static final PacketCodec<RegistryByteBuf, CharacteristicsModule.Data> CHARACTERISTICS_PACKET_CODEC =
@@ -130,6 +134,7 @@ public class PetsplusComponents {
                 PacketCodecs.optional(HISTORY_PACKET_CODEC).encode(buf, data.history());
                 PacketCodecs.optional(INVENTORY_PACKET_CODEC).encode(buf, data.inventories());
                 PacketCodecs.optional(OWNER_PACKET_CODEC).encode(buf, data.owner());
+                PacketCodecs.optional(RELATIONSHIP_PACKET_CODEC).encode(buf, data.relationships());
                 PacketCodecs.optional(SCHEDULING_PACKET_CODEC).encode(buf, data.scheduling());
                 PacketCodecs.optional(CHARACTERISTICS_PACKET_CODEC).encode(buf, data.characteristics());
                 PacketCodecs.optional(GOSSIP_PACKET_CODEC).encode(buf, data.gossip());
@@ -147,6 +152,7 @@ public class PetsplusComponents {
                 Optional<HistoryModule.Data> history = PacketCodecs.optional(HISTORY_PACKET_CODEC).decode(buf);
                 Optional<InventoryModule.Data> inventories = PacketCodecs.optional(INVENTORY_PACKET_CODEC).decode(buf);
                 Optional<OwnerModule.Data> owner = PacketCodecs.optional(OWNER_PACKET_CODEC).decode(buf);
+                Optional<RelationshipModule.Data> relationships = PacketCodecs.optional(RELATIONSHIP_PACKET_CODEC).decode(buf);
                 Optional<SchedulingModule.Data> scheduling = PacketCodecs.optional(SCHEDULING_PACKET_CODEC).decode(buf);
                 Optional<CharacteristicsModule.Data> characteristics = PacketCodecs.optional(CHARACTERISTICS_PACKET_CODEC).decode(buf);
                 Optional<PetGossipLedger> gossip = PacketCodecs.optional(GOSSIP_PACKET_CODEC).decode(buf);
@@ -155,7 +161,7 @@ public class PetsplusComponents {
                 int schemaVersion = PacketCodecs.VAR_INT.decode(buf);
 
                 return new PetData(roleId.map(Identifier::of), cooldowns, lastAttackTick, isPerched,
-                    xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+                    xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
             }
         );
 
@@ -193,78 +199,82 @@ public class PetsplusComponents {
 
         public static PetData empty() {
             return new PetData(Optional.empty(), Map.of(), 0, false, -1L,
-                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), CURRENT_SCHEMA_VERSION);
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), CURRENT_SCHEMA_VERSION);
         }
 
         public PetData withRole(Identifier roleId) {
-            return new PetData(Optional.of(roleId), cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(Optional.of(roleId), cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withCooldown(String key, long value) {
             Map<String, Long> newCooldowns = new java.util.HashMap<>(cooldowns);
             newCooldowns.put(key, value);
-            return new PetData(role, newCooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, newCooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withLastAttackTick(long tick) {
-            return new PetData(role, cooldowns, tick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, tick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withPerched(boolean perched) {
-            return new PetData(role, cooldowns, lastAttackTick, perched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, perched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withXpFlashStartTick(long tick) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, tick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, tick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withProgression(ProgressionModule.Data data) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, Optional.of(data), history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, Optional.of(data), history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withHistory(HistoryModule.Data data) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, Optional.of(data), inventories, owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, Optional.of(data), inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withInventories(InventoryModule.Data data) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, Optional.of(data), owner, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, Optional.of(data), owner, relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withOwner(OwnerModule.Data data) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, Optional.of(data), scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, Optional.of(data), relationships, scheduling, characteristics, gossip, mood, stateData, schemaVersion);
+        }
+
+        public PetData withRelationships(RelationshipModule.Data data) {
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, Optional.ofNullable(data), scheduling, characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withScheduling(SchedulingModule.Data data) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, Optional.of(data), characteristics, gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, Optional.of(data), characteristics, gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withCharacteristics(CharacteristicsModule.Data data) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, Optional.of(data), gossip, mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, Optional.of(data), gossip, mood, stateData, schemaVersion);
         }
 
         public PetData withStateData(NbtCompound data) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, Optional.of(data), schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, Optional.of(data), schemaVersion);
         }
 
         public PetData withGossip(PetGossipLedger ledger) {
             if (ledger == null || ledger.isEmpty()) {
-                return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, Optional.empty(), mood, stateData, schemaVersion);
+                return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, Optional.empty(), mood, stateData, schemaVersion);
             }
             PetGossipLedger snapshot = new PetGossipLedger();
             snapshot.copyFrom(ledger);
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, Optional.of(snapshot), mood, stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, Optional.of(snapshot), mood, stateData, schemaVersion);
         }
 
         public PetData withMood(NbtCompound moodData) {
             NbtCompound copy = moodData == null ? new NbtCompound() : moodData.copy();
             if (copy.getKeys().isEmpty()) {
-                return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, Optional.empty(), stateData, schemaVersion);
+                return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, Optional.empty(), stateData, schemaVersion);
             }
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, Optional.of(copy), stateData, schemaVersion);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, Optional.of(copy), stateData, schemaVersion);
         }
 
         public PetData withSchemaVersion(int version) {
-            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, scheduling, characteristics, gossip, mood, stateData, version);
+            return new PetData(role, cooldowns, lastAttackTick, isPerched, xpFlashStartTick, progression, history, inventories, owner, relationships, scheduling, characteristics, gossip, mood, stateData, version);
         }
     }
     

--- a/src/main/java/woflo/petsplus/state/processing/OwnerProcessingGroup.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerProcessingGroup.java
@@ -63,6 +63,27 @@ final class OwnerProcessingGroup {
         if (petLookup.remove(pet) != null) {
             petCacheDirty = true;
         }
+
+        if (!pendingTasks.isEmpty()) {
+            var iterator = pendingTasks.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> entry = iterator.next();
+                List<PetWorkScheduler.ScheduledTask> tasks = entry.getValue();
+                if (tasks == null || tasks.isEmpty()) {
+                    if (tasks != null) {
+                        PooledTaskLists.recycle(tasks);
+                    }
+                    iterator.remove();
+                    continue;
+                }
+
+                tasks.removeIf(task -> task == null || task.component() == component);
+                if (tasks.isEmpty()) {
+                    PooledTaskLists.recycle(tasks);
+                    iterator.remove();
+                }
+            }
+        }
     }
 
     boolean isEmpty() {

--- a/src/main/java/woflo/petsplus/state/processing/OwnerProcessingManager.java
+++ b/src/main/java/woflo/petsplus/state/processing/OwnerProcessingManager.java
@@ -88,11 +88,23 @@ public final class OwnerProcessingManager {
             return;
         }
         UUID ownerId = component.getOwnerUuid();
+        UUID previousOwner = membership.put(component, ownerId);
+        if (previousOwner != null && (ownerId == null || !previousOwner.equals(ownerId))) {
+            OwnerProcessingGroup previousGroup = groups.get(previousOwner);
+            if (previousGroup != null) {
+                previousGroup.untrack(component);
+                if (previousGroup.currentPets().isEmpty()) {
+                    removeGroupFromDueQueue(previousGroup);
+                    groups.remove(previousOwner, previousGroup);
+                    previousGroup.clear();
+                }
+            }
+        }
         if (ownerId == null) {
+            membership.remove(component);
             return;
         }
         OwnerProcessingGroup group = groups.computeIfAbsent(ownerId, OwnerProcessingGroup::new);
-        membership.put(component, ownerId);
         group.markPetChanged(component, currentTick);
     }
 

--- a/src/test/java/woflo/petsplus/state/PetComponentRelationshipPersistenceTest.java
+++ b/src/test/java/woflo/petsplus/state/PetComponentRelationshipPersistenceTest.java
@@ -1,0 +1,61 @@
+package woflo.petsplus.state;
+
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+import org.junit.jupiter.api.Test;
+import woflo.petsplus.component.PetsplusComponents;
+import woflo.petsplus.state.modules.RelationshipModule;
+import woflo.petsplus.state.relationships.InteractionType;
+import woflo.petsplus.state.relationships.RelationshipProfile;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PetComponentRelationshipPersistenceTest {
+
+    @Test
+    void relationshipModuleStateSurvivesSerializationRoundTrip() {
+        MinecraftServer server = new MinecraftServer();
+        ServerWorld world = new ServerWorld(server);
+        MobEntity pet = new MobEntity(world);
+        PetComponent component = new PetComponent(pet);
+
+        UUID entityId = UUID.randomUUID();
+        RelationshipModule relationshipModule = component.getRelationshipModule();
+
+        relationshipModule.recordInteraction(entityId, InteractionType.PETTING, 1200L, 1.0f, 1.0f, 1.0f);
+        relationshipModule.recordInteraction(entityId, InteractionType.FEEDING, 1230L, 1.0f, 1.0f, 1.0f);
+
+        RelationshipProfile before = relationshipModule.getRelationship(entityId);
+        assertNotNull(before, "Expected relationship profile to be created after interactions");
+
+        PetsplusComponents.PetData serialized = component.toComponentData();
+        assertTrue(serialized.relationships().isPresent(), "Serialized payload should include relationships when data exists");
+
+        PetComponent reloaded = new PetComponent(new MobEntity(world));
+        reloaded.fromComponentData(serialized);
+
+        RelationshipProfile after = reloaded.getRelationshipModule().getRelationship(entityId);
+        assertNotNull(after, "Relationship profile should persist through serialization");
+
+        assertEquals(before.trust(), after.trust(), 1.0e-4f, "Trust should be preserved");
+        assertEquals(before.affection(), after.affection(), 1.0e-4f, "Affection should be preserved");
+        assertEquals(before.respect(), after.respect(), 1.0e-4f, "Respect should be preserved");
+    }
+
+    @Test
+    void emptyRelationshipModuleOmitsSerializationPayload() {
+        MinecraftServer server = new MinecraftServer();
+        ServerWorld world = new ServerWorld(server);
+        PetComponent component = new PetComponent(new MobEntity(world));
+
+        PetsplusComponents.PetData serialized = component.toComponentData();
+
+        assertTrue(serialized.relationships().isEmpty(), "Empty relationship module should not serialize data");
+    }
+}
+

--- a/src/test/java/woflo/petsplus/state/processing/OwnerProcessingManagerTest.java
+++ b/src/test/java/woflo/petsplus/state/processing/OwnerProcessingManagerTest.java
@@ -1,15 +1,21 @@
 package woflo.petsplus.state.processing;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+
+import net.minecraft.entity.mob.MobEntity;
 
 import woflo.petsplus.state.PetComponent;
 import woflo.petsplus.state.coordination.PetWorkScheduler;
@@ -64,6 +70,65 @@ class OwnerProcessingManagerTest {
         assertTrue(extractMembership(manager).isEmpty(), "Membership should be cleared during shutdown");
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void markPetChangedReassignsOwnershipAndCleansUpOldGroup() throws Exception {
+        OwnerProcessingManager manager = new OwnerProcessingManager();
+        UUID originalOwner = UUID.randomUUID();
+        UUID newOwner = UUID.randomUUID();
+
+        PetComponent component = mock(PetComponent.class);
+        MobEntity petEntity = mock(MobEntity.class);
+        when(component.getPetEntity()).thenReturn(petEntity);
+        when(component.getOwnerUuid()).thenReturn(originalOwner);
+
+        manager.trackPet(component);
+        manager.onTaskScheduled(component, PetWorkScheduler.TaskType.INTERVAL, 5L);
+
+        Map<UUID, OwnerProcessingGroup> groups = (Map<UUID, OwnerProcessingGroup>) extractGroups(manager);
+        OwnerProcessingGroup originalGroup = groups.get(originalOwner);
+        assertNotNull(originalGroup, "Original owner group should be created");
+        assertTrue(originalGroup.currentPets().contains(component), "Original group should track the pet");
+        assertTrue(originalGroup.hasDueEvents(5L), "Original group should have a due event after scheduling");
+
+        Map<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> pendingTasks =
+            extractPendingTasks(originalGroup);
+        PetWorkScheduler.ScheduledTask scheduledTask = mock(PetWorkScheduler.ScheduledTask.class);
+        when(scheduledTask.component()).thenReturn(component);
+        when(scheduledTask.type()).thenReturn(PetWorkScheduler.TaskType.INTERVAL);
+        List<PetWorkScheduler.ScheduledTask> taskBucket = new ArrayList<>();
+        taskBucket.add(scheduledTask);
+        pendingTasks.put(PetWorkScheduler.TaskType.INTERVAL, taskBucket);
+        assertTrue(originalGroup.hasPendingTasks(), "Original group should report pending tasks before transfer");
+
+        when(component.getOwnerUuid()).thenReturn(newOwner);
+        manager.markPetChanged(component, 10L);
+
+        assertFalse(originalGroup.currentPets().contains(component), "Pet should be removed from the original group");
+        assertFalse(originalGroup.hasDueEvents(10L), "Original group should not retain due events after transfer");
+        assertFalse(originalGroup.hasPendingTasks(), "Original group should drop pending tasks after transfer");
+        groups = (Map<UUID, OwnerProcessingGroup>) extractGroups(manager);
+        assertFalse(groups.containsKey(originalOwner), "Original owner group should be recycled after transfer");
+
+        OwnerProcessingGroup reassignedGroup = groups.get(newOwner);
+        assertNotNull(reassignedGroup, "New owner group should be created on transfer");
+        assertTrue(reassignedGroup.currentPets().contains(component), "Pet should now be tracked by the new owner");
+
+        Map<PetComponent, UUID> membership = extractMembership(manager);
+        assertEquals(newOwner, membership.get(component), "Membership should point to the new owner");
+
+        when(component.getOwnerUuid()).thenReturn(null);
+        manager.markPetChanged(component, 15L);
+
+        assertFalse(reassignedGroup.currentPets().contains(component), "Pet should be removed from new owner when unassigned");
+        assertFalse(reassignedGroup.hasDueEvents(15L), "New owner group should clear due events when emptied");
+        groups = (Map<UUID, OwnerProcessingGroup>) extractGroups(manager);
+        assertFalse(groups.containsKey(newOwner), "New owner group should be recycled when empty");
+
+        membership = extractMembership(manager);
+        assertFalse(membership.containsKey(component), "Membership should not retain pets without owners");
+    }
+
     @SuppressWarnings("unchecked")
     private static Map<UUID, ?> extractGroups(OwnerProcessingManager manager) throws Exception {
         Field field = OwnerProcessingManager.class.getDeclaredField("groups");
@@ -89,5 +154,14 @@ class OwnerProcessingManagerTest {
         Field field = OwnerProcessingManager.class.getDeclaredField("membership");
         field.setAccessible(true);
         return (Map<PetComponent, UUID>) field.get(manager);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>> extractPendingTasks(
+        OwnerProcessingGroup group
+    ) throws Exception {
+        Field field = OwnerProcessingGroup.class.getDeclaredField("pendingTasks");
+        field.setAccessible(true);
+        return (Map<PetWorkScheduler.TaskType, List<PetWorkScheduler.ScheduledTask>>) field.get(group);
     }
 }


### PR DESCRIPTION
## Summary
- drop pending scheduled tasks from an owner group when a pet is untracked so reassigned pets stop contributing stale work
- extend the ownership transfer regression test to cover queued tasks and assert they are removed during the move

## Testing
- ./gradlew test --tests woflo.petsplus.state.processing.OwnerProcessingManagerTest --tests woflo.petsplus.state.PetComponentRelationshipPersistenceTest

------
https://chatgpt.com/codex/tasks/task_e_68e52de9f3b8832f93dd3cc24a98844b