### PR TITLE
Fix owner lookup to persist across player disconnects

### DIFF
--- a/src/main/java/woflo/petsplus/state/modules/impl/DefaultOwnerModule.java
+++ b/src/main/java/woflo/petsplus/state/modules/impl/DefaultOwnerModule.java
@@ -35,6 +35,13 @@ public class DefaultOwnerModule implements OwnerModule {
         // Try to resolve owner from UUID if cache is empty
         if (ownerCache == null && ownerUuid != null) {
             PlayerEntity resolved = world.getPlayerByUuid(ownerUuid);
+
+            if (resolved == null && world.getServer() != null) {
+                resolved = world.getServer()
+                    .getPlayerManager()
+                    .getPlayer(ownerUuid);
+            }
+
             if (resolved != null) {
                 ownerCache = resolved;
             }


### PR DESCRIPTION
## Summary
- resolve pet owners using the server-wide player manager when the local world cache misses so disconnected owners are recovered on reconnect

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68e5d7c68444832faccff485dbd1ab4c