### PR TITLE
Track combat participation when owners or pets deal damage

### DIFF
--- a/src/main/java/woflo/petsplus/events/CombatEventHandler.java
+++ b/src/main/java/woflo/petsplus/events/CombatEventHandler.java
@@ -709,6 +709,10 @@ public class CombatEventHandler {
     }
     
     private static void handleOwnerDealtDamage(PlayerEntity owner, LivingEntity victim, float damage) {
+        if (damage > 0.0F && owner instanceof ServerPlayerEntity serverOwner
+            && owner.getEntityWorld() instanceof ServerWorld) {
+            XpEventHandler.trackPlayerCombat(serverOwner);
+        }
         OwnerCombatState combatState = OwnerCombatState.getOrCreate(owner);
         combatState.enterCombat();
         long now = owner.getEntityWorld().getTime();
@@ -1446,10 +1450,13 @@ public class CombatEventHandler {
      * Handle when a pet deals damage - triggers aggressive/triumphant emotions based on context
      */
     private static void handlePetDealtDamage(MobEntity pet, PetComponent petComponent, LivingEntity victim, float damage) {
+        if (damage > 0.0F && pet.getEntityWorld() instanceof ServerWorld) {
+            XpEventHandler.trackPetCombat(pet);
+        }
         float victimMaxHealth = Math.max(1f, victim.getMaxHealth());
         float damageIntensity = damageIntensity(damage, victimMaxHealth);
         PlayerEntity owner = petComponent.getOwner();
-        
+
         // Ensure thread-safe access to pet state
         synchronized (pet) {
             long now = pet.getEntityWorld().getTime();

--- a/src/main/java/woflo/petsplus/events/LeadTradingHandler.java
+++ b/src/main/java/woflo/petsplus/events/LeadTradingHandler.java
@@ -7,6 +7,7 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import woflo.petsplus.Petsplus;
+import woflo.petsplus.config.PetsPlusConfig;
 import woflo.petsplus.handler.PetTradingHandler;
 
 /**
@@ -51,6 +52,11 @@ public class LeadTradingHandler {
         // Forward interactions with other players to the trading handler. It will enforce any
         // configuration requirements (such as requiring the initiator to sneak).
         if (entity instanceof PlayerEntity targetPlayer) {
+            boolean requireSneak = PetsPlusConfig.getInstance().isLeashTradingSneakRequired();
+            if (requireSneak && !player.isSneaking()) {
+                return ActionResult.PASS;
+            }
+
             ActionResult result = PetTradingHandler.tryInitiateTrade(player, targetPlayer, hand);
             if (result != ActionResult.PASS) {
                 return result;

--- a/src/main/java/woflo/petsplus/events/LeadTradingHandler.java
+++ b/src/main/java/woflo/petsplus/events/LeadTradingHandler.java
@@ -11,7 +11,8 @@ import woflo.petsplus.handler.PetTradingHandler;
 
 /**
  * Event handler for lead trading interactions.
- * Uses UseEntityCallback to detect when players use leads on other players while sneaking.
+ * Uses UseEntityCallback to detect when players use leads on other players and forwards the
+ * interaction to the trading handler, which enforces configuration such as sneaking requirements.
  */
 public class LeadTradingHandler {
     
@@ -30,9 +31,9 @@ public class LeadTradingHandler {
      * This method is called when a player right-clicks on an entity.
      * 
      * Key mechanic: When a lead is attached to a mob (mob is leashed), the lead item
-     * is no longer in the player's hand - it's an active connection. So we detect
-     * shift-right-click on another player and check if the clicking player has any
-     * leashed mobs nearby (where mob.getLeashHolder() == player).
+     * is no longer in the player's hand - it's an active connection. So we forward
+     * the interaction on another player and let the trading handler determine if the
+     * initiator meets configuration like sneaking requirements and nearby leashed pets.
      * 
      * @param player The player using the item
      * @param world The world where the interaction occurs
@@ -47,16 +48,15 @@ public class LeadTradingHandler {
             return ActionResult.PASS;
         }
         
-        // Check if player is sneaking and targeting another player
-        if (player.isSneaking() && entity instanceof PlayerEntity targetPlayer) {
-            // When a player has leashed pets, they can trade them by shift-right-clicking another player
-            // The lead is already attached to the mob, not in hand
+        // Forward interactions with other players to the trading handler. It will enforce any
+        // configuration requirements (such as requiring the initiator to sneak).
+        if (entity instanceof PlayerEntity targetPlayer) {
             ActionResult result = PetTradingHandler.tryInitiateTrade(player, targetPlayer, hand);
             if (result != ActionResult.PASS) {
                 return result;
             }
         }
-        
+
         return ActionResult.PASS;
     }
 }

--- a/src/main/java/woflo/petsplus/events/PetDeathHandler.java
+++ b/src/main/java/woflo/petsplus/events/PetDeathHandler.java
@@ -145,6 +145,7 @@ public class PetDeathHandler {
         
         // Remove the pet component (marks for cleanup)
         PetComponent.remove(pet);
+        PetDetectionHandler.clearPending(pet);
         
         // Remove the pet entity from the world permanently
         pet.discard(); // This removes the entity completely

--- a/src/main/java/woflo/petsplus/events/SupportInteractionHandler.java
+++ b/src/main/java/woflo/petsplus/events/SupportInteractionHandler.java
@@ -113,8 +113,10 @@ public class SupportInteractionHandler {
 
         SupportPotionUtils.writeStoredState(comp, outcome.result());
 
-        // Consume exactly one from the player stack
-        stack.decrement(1);
+        // Consume exactly one from the player stack (unless creative)
+        if (!player.getAbilities().creativeMode) {
+            stack.decrement(1);
+        }
 
         // Feedback
         ((ServerWorld) world).spawnParticles(net.minecraft.particle.ParticleTypes.HEART,

--- a/src/main/java/woflo/petsplus/events/TributeHandler.java
+++ b/src/main/java/woflo/petsplus/events/TributeHandler.java
@@ -185,7 +185,7 @@ public class TributeHandler {
     private static boolean payTribute(ServerPlayerEntity player, MobEntity pet, PetComponent petComp, int milestoneLevel, Item tributeItem, ItemStack stack, boolean consumeItem) {
         try {
             // Consume exactly one item
-            if (consumeItem) {
+            if (consumeItem && !player.getAbilities().creativeMode) {
                 stack.decrement(1);
             }
 

--- a/src/main/java/woflo/petsplus/mechanics/CursedOneResurrection.java
+++ b/src/main/java/woflo/petsplus/mechanics/CursedOneResurrection.java
@@ -21,6 +21,7 @@ import woflo.petsplus.state.PetComponent;
 import woflo.petsplus.ui.AfterimageManager;
 import woflo.petsplus.ui.UIFeedbackManager;
 import woflo.petsplus.roles.cursedone.CursedOneSoulSacrificeManager;
+import woflo.petsplus.events.PetDetectionHandler;
 
 import java.util.List;
 import java.util.Map;
@@ -1147,6 +1148,7 @@ public class CursedOneResurrection {
         );
         
         // Remove the pet component first to prevent death penalty
+        PetDetectionHandler.clearPending(cursedPet);
         PetComponent.remove(cursedPet);
         
         // Kill the pet
@@ -1298,6 +1300,7 @@ public class CursedOneResurrection {
         }
 
         // Remove the pet component first to prevent normal death penalty
+        PetDetectionHandler.clearPending(cursedPet);
         PetComponent.remove(cursedPet);
 
         // Kill the pet with magic damage (representing the cursed bond)

--- a/src/main/java/woflo/petsplus/ui/PetInspectionManager.java
+++ b/src/main/java/woflo/petsplus/ui/PetInspectionManager.java
@@ -288,6 +288,8 @@ public final class PetInspectionManager {
         MobEntity best = null;
         for (Entity e : player.getEntityWorld().getOtherEntities(player, player.getBoundingBox().expand(VIEW_DIST))) {
             if (!(e instanceof MobEntity mob)) continue;
+            if (!player.canSee(mob)) continue;
+            if (mob.isInvisibleTo(player)) continue;
             Vec3d to = e.getEntityPos().add(0, e.getStandingEyeHeight() * 0.5, 0).subtract(start).normalize();
             double dot = to.dotProduct(look);
             if (dot > bestDot && player.squaredDistanceTo(e) <= VIEW_DIST * VIEW_DIST) {


### PR DESCRIPTION
## Summary
- update the combat event handler to refresh owner participation whenever server-side damage lands
- track pet combat timestamps on the server so pet hits also maintain the participation bonus window

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e65623f830832f9c8c7767b0bf9f0d